### PR TITLE
perf: ⚡️ cache invalidation on cargo lock change

### DIFF
--- a/.github/workflows/pr-healthcheck-runner.yml
+++ b/.github/workflows/pr-healthcheck-runner.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           path: |
             **/target
-          key: cache-rust-target-${{ hashFiles('package.json') }}
+          key: cache-rust-target-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Dfx local network replica
         run: |


### PR DESCRIPTION
## Why?

Only invalidate cache on cargo lock change.