### PR TITLE
chore: update crowns and Dip721Proxy to correct DIP721v2 spec (wip)

### DIFF
--- a/.scripts/healthcheck.sh
+++ b/.scripts/healthcheck.sh
@@ -395,9 +395,4 @@ run() {
 
 run
 
-echo "🤖 Clear identities for Alice and Bob"
-
-dfx identity remove "$ALICE_IDENTITY_NAME"
-dfx identity remove "$BOB_IDENTITY_NAME"
-
 echo "👍 Healthcheck completed!"

--- a/.scripts/healthcheck.sh
+++ b/.scripts/healthcheck.sh
@@ -192,7 +192,7 @@ listForSale() {
     listForSale "(
         principal \"$_nonFungibleContractAddress\",
         $_token_id,
-        ($_list_price:nat)
+        $_list_price:nat
       )"
 }
 

--- a/.scripts/mocks/generate-mocks.sh
+++ b/.scripts/mocks/generate-mocks.sh
@@ -139,7 +139,6 @@ generatorHandler() {
 
 # Distribute the total number of tokens
 dividedTotal=$((totalNumberOfTokens / 3))
-printf "$dividedTotal"
 dividedTotal=$(echo "$dividedTotal" | awk '{print int($1+0.5)}')
 
 userTotal=$((dividedTotal + (totalNumberOfTokens - ($dividedTotal*3))))

--- a/.scripts/mocks/generate-mocks.sh
+++ b/.scripts/mocks/generate-mocks.sh
@@ -29,7 +29,7 @@ generateMock() {
 
   crownsNftCanisterId="vlhm2-4iaaa-aaaam-qaatq-cai"
   filename=$(printf "%04d.mp4" "$token_index")
-  crownsCertifiedAssetsA="vzb3d-qyaaa-aaaam-qaaqq-ca"
+  crownsCertifiedAssetsA="vzb3d-qyaaa-aaaam-qaaqq-cai"
   crownsCertifiedAssetsB="vqcq7-gqaaa-aaaam-qaara-cai"
   assetUrl="https://$crownsCertifiedAssetsA.raw.ic0.app/$filename"
 

--- a/.scripts/mocks/generate-mocks.sh
+++ b/.scripts/mocks/generate-mocks.sh
@@ -8,12 +8,12 @@
 . ".scripts/dfx-identity.sh"
 
 # The NFT Canister id
-nftCanisterId=$1
+nftCanisterId=$(cd crowns && dfx canister id crowns)
 
 # The total tokens to generate
-totalNumberOfTokens=$2
+totalNumberOfTokens=$1
 
-token_index=$3
+token_index=$2
 
 if [[ -z $3 ]];
 then

--- a/.scripts/mocks/generate-mocks.sh
+++ b/.scripts/mocks/generate-mocks.sh
@@ -15,7 +15,7 @@ totalNumberOfTokens=$1
 
 token_index=$2
 
-if [[ -z $3 ]];
+if [[ -z $token_index ]];
 then
   printf "🤖 The token index start from not provided (default is 0)\n"
   token_index=0

--- a/.scripts/mocks/generate-mocks.sh
+++ b/.scripts/mocks/generate-mocks.sh
@@ -17,7 +17,7 @@ token_index=$3
 
 if [[ -z $3 ]];
 then
-  printf "🤖 The token index start from not provided (default is 1)\n"
+  printf "🤖 The token index start from not provided (default is 0)\n"
   token_index=0
 fi
 
@@ -139,14 +139,17 @@ generatorHandler() {
 
 # Distribute the total number of tokens
 dividedTotal=$((totalNumberOfTokens / 3))
+printf "$dividedTotal"
 dividedTotal=$(echo "$dividedTotal" | awk '{print int($1+0.5)}')
+
+userTotal=$((dividedTotal + (totalNumberOfTokens - ($dividedTotal*3))))
 
 # Warn the user about identity requirement
 # as the end user will be interacting with the Marketplace via Plug's
 userIdentityWarning "$DEFAULT_PRINCIPAL_ID"
 
 # generates mock data for the dfx user principal
-generatorHandler "$INITIAL_IDENTITY" "$DEFAULT_PRINCIPAL_ID" "$dividedTotal"
+generatorHandler "$INITIAL_IDENTITY" "$DEFAULT_PRINCIPAL_ID" "$userTotal"
 
 # generates mock data for Alice
 generatorHandler "$ALICE_IDENTITY_NAME" "$ALICE_PRINCIPAL_ID" "$dividedTotal"

--- a/marketplace/src/main.rs
+++ b/marketplace/src/main.rs
@@ -66,8 +66,6 @@ pub async fn list_for_sale(
         .entry((non_fungible_contract_address, token_id.clone()))
         .or_default();
 
-    print!("{:?} {}", sale_offer, token_owner.unwrap());
-
     if (sale_offer.status == SaleOfferStatus::Selling) {
         return Err(MPApiError::InvalidSaleOfferStatus);
     }

--- a/marketplace/src/main.rs
+++ b/marketplace/src/main.rs
@@ -55,7 +55,7 @@ pub async fn list_for_sale(
     )
     .await?;
     
-    if (caller != token_owner) {
+    if (caller != token_owner.unwrap()) {
         return Err(MPApiError::Unauthorized);
     }
 
@@ -65,6 +65,8 @@ pub async fn list_for_sale(
         .sale_offers
         .entry((non_fungible_contract_address, token_id.clone()))
         .or_default();
+
+    print!("{:?} {}", sale_offer, token_owner.unwrap());
 
     if (sale_offer.status == SaleOfferStatus::Selling) {
         return Err(MPApiError::InvalidSaleOfferStatus);
@@ -78,7 +80,7 @@ pub async fn list_for_sale(
                 .caller(caller)
                 .operation("makeSaleOffer")
                 .details(vec![
-                    ("token_id".into(), DetailValue::Text(token_id.to_string())),
+                    ("token_id".into(), DetailValue::U64(token_id)),
                     (
                         "non_fungible_contract_address".into(),
                         DetailValue::Principal(collection.non_fungible_contract_address),
@@ -209,7 +211,7 @@ pub async fn accept_buy_offer(buy_id: u64) -> MPApiResult {
     )
     .await?;
 
-    if (sale_offer.payment_address != token_owner) {
+    if (sale_offer.payment_address != token_owner.unwrap()) {
         mp.sale_offers.remove(&(
             buy_offer.non_fungible_contract_address,
             buy_offer.token_id.clone(),
@@ -381,7 +383,7 @@ pub async fn direct_buy(non_fungible_contract_address: Principal, token_id: u64)
         collection.non_fungible_token_type.clone(),
     )
     .await?;
-    if (sale_offer.payment_address != token_owner) {
+    if (sale_offer.payment_address != token_owner.unwrap()) {
         mp.sale_offers
             .remove(&(non_fungible_contract_address, token_id.clone()));
         return Err(MPApiError::InsufficientNonFungibleBalance);

--- a/marketplace/src/non_fungible_proxy.rs
+++ b/marketplace/src/non_fungible_proxy.rs
@@ -90,8 +90,8 @@ impl Dip721Proxy {
         }
     }
 
-    pub async fn owner_of(contract: &Principal, token_id: &u64) -> Result<Principal, MPApiError> {
-        let call_res: Result<(Result<Principal, NftError>,), (RejectionCode, String)> = ic::call(
+    pub async fn owner_of(contract: &Principal, token_id: &u64) -> Result<Option<Principal>, MPApiError> {
+        let call_res: Result<(Result<Option<Principal>, NftError>,), (RejectionCode, String)> = ic::call(
             *contract,
             "ownerOf",
             (Nat::from(token_id.clone()),),

--- a/marketplace/src/types.rs
+++ b/marketplace/src/types.rs
@@ -20,7 +20,7 @@ pub enum BuyOfferStatus {
     Bought,
 }
 
-#[derive(Clone, CandidType, Deserialize, Eq, PartialEq)]
+#[derive(Clone, CandidType, Deserialize, Debug, Eq, PartialEq)]
 pub enum SaleOfferStatus {
     Uninitialized,
     Created,
@@ -32,7 +32,7 @@ pub struct InitData {
     pub owner: Principal,
 }
 
-#[derive(Clone, CandidType, Deserialize, new)]
+#[derive(Clone, CandidType, Deserialize, Debug, new)]
 pub struct SaleOffer {
     pub is_direct_buyable: bool,
     pub list_price: Nat,
@@ -113,7 +113,7 @@ pub enum MPApiError {
 }
 
 pub type MPApiResult = Result<(), MPApiError>;
-pub type PrincipalResult = Result<Principal, MPApiError>;
+pub type PrincipalResult = Result<Option<Principal>, MPApiError>;
 pub type U64Result = Result<u64, MPApiError>;
 pub type NatResult = Result<Nat, MPApiError>;
 


### PR DESCRIPTION
## Why?

update crowns and marketplace to align with correct dip721v2 spec

## How

 - [x] update crowns repo
 - [x] fix rounding error in mock-generate, adds missing tokens to dfx user principal
 - [x] update marketplace dip721v2 spec

## Tickets?

- https://github.com/Psychedelic/nft-marketplace-fe/pull/54

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] It does not break existing features (unless required)
- [ ] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [ ] All code formatting pass
- [ ] All lints pass
- [ ] All tests pass

## Security checklist?

- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] Sensitive data has been identified and is being protected 