### PR TITLE
chore: 🤖 optimize the build process to reduce file size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,8 @@ exclude = [
     "crowns",
     "wicp",
 ]
+
+[profile.release]
+lto = true
+opt-level = 'z'
+codegen-units = 1

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cargo build --target wasm32-unknown-unknown --release --package marketplace
+
+ic-cdk-optimizer ./target/wasm32-unknown-unknown/release/marketplace.wasm -o ./target/wasm32-unknown-unknown/release/marketplace-opt.wasm

--- a/dfx.json
+++ b/dfx.json
@@ -33,7 +33,7 @@
     "marketplace": {
       "build": "./build.sh",
       "candid": "marketplace/marketplace.did",
-      "wasm": "target/wasm32-unknown-unknown/release/marketplace.wasm",
+      "wasm": "target/wasm32-unknown-unknown/release/marketplace-opt.wasm",
       "type": "custom"
     }
   },

--- a/dfx.json
+++ b/dfx.json
@@ -31,7 +31,7 @@
       "type": "custom"
     },
     "marketplace": {
-      "build": "cargo build --target wasm32-unknown-unknown --release --package marketplace",
+      "build": "./build.sh",
       "candid": "marketplace/marketplace.did",
       "wasm": "target/wasm32-unknown-unknown/release/marketplace.wasm",
       "type": "custom"


### PR DESCRIPTION
## Why?

The build artifact exceeds 2mb, while an optimize version reduces the size to 52%, as we can see in the logs.

## How?

- Create a build script which calls ic-cdk-optimizer
- Update dfx.json to call build script
- Update Cargo toml to use recommended opt settings

## Demo?

```sh
)
   Compiling cap-sdk v0.1.0-alpha1 (https://github.com/Psychedelic/cap.git?branch=main#caf6e873)
   Compiling cap-standards v0.1.0-alpha1 (https://github.com/Psychedelic/cap.git?branch=main#caf6e873)
   Compiling marketplace v0.1.0 (/Users/punkbit/www/fleek/nft-marketplace-fe/nft-marketplace/marketplace)
    Finished release [optimized] target(s) in 1m 07s
Original:          1.04 MiB
Stripping Unused Data Segments...
    Size:          540.50 KiB (49.0% smaller)
Execute a binaryen optimization pass on your WASM....
    Size:          502.56 KiB (7.0% smaller)

Final Size: 502.56 KiB (52.6% smaller)
```

```
-rw-r--r--    1 punkbit  staff   514626 30 Mar 17:50 marketplace-opt.wasm
-rw-r--r--    1 punkbit  staff      654 16 Feb 15:01 marketplace.d
-rwxr-xr-x    2 punkbit  staff  1086030 30 Mar 17:50 marketplace.wasm
```