### PR TITLE
feat: non binding offers and `serviceBalanceOf()` interface

### DIFF
--- a/.scripts/healthcheck.sh
+++ b/.scripts/healthcheck.sh
@@ -74,10 +74,17 @@ mintDip721() {
   _mint_for=$2
   _nonFungibleContractAddress=$3
 
+  crownsNftCanisterId="vlhm2-4iaaa-aaaam-qaatq-cai"
+
   printf "🤖 The mintDip721 has nonFungibleContractAddress (%s), 
   mint_for user (%s) of id (%s)\n" "$_nonFungibleContractAddress" "$_name" "$_mint_for"
 
-  nft_token_id_for_alice=$RANDOM
+  example_nft=$(echo "$RANDOM%5000 + 1" | bc)
+  mainnetMetadataResult=($(dfx canister --network ic call $crownsNftCanisterId getMetadataDip721 "($example_nft:nat64)" | pcregrep -o1  '3_643_416_556 = "([a-zA-Z]*)"'))
+
+  echo $mainnetMetadataResult
+
+  nft_token_id_for_alice=$(echo "$example_nft + 10000" | bc) # shift out of crowns index space
 
   _result=$(
     dfx canister \
@@ -87,15 +94,39 @@ mintDip721() {
         $nft_token_id_for_alice:nat,
         vec {
           record {
+            \"smallgem\";
+            variant {
+              \"TextContent\" = \"${mainnetMetadataResult[0]}\"
+            }
+          };
+          record {
+            \"biggem\";
+            variant {
+              \"TextContent\" = \"${mainnetMetadataResult[1]}\"
+            }
+          };
+          record {
+            \"base\";
+            variant {
+              \"TextContent\" = \"${mainnetMetadataResult[2]}\"
+            }
+          };
+          record {
+            \"rim\";
+            variant {
+              \"TextContent\" = \"${mainnetMetadataResult[3]}\"
+            }
+          };
+          record {
             \"location\";
             variant {
-              \"TextContent\" = \"https://vzb3d-qyaaa-aaaam-qaaqq-cai.raw.ic0.app/0000.mp4\"
+              \"TextContent\" = \"https://vzb3d-qyaaa-aaaam-qaaqq-cai.raw.ic0.app/$example_nft.mp4\"
             }
           };
           record {
             \"thumbnail\";
             variant {
-              \"TextContent\" = \"https://vzb3d-qyaaa-aaaam-qaaqq-cai.raw.ic0.app/thumbnail/0000.png\"
+              \"TextContent\" = \"https://vzb3d-qyaaa-aaaam-qaaqq-cai.raw.ic0.app/thumbnail/$example_nft.png\"
             }
           };
         }
@@ -431,14 +462,14 @@ accept_offer() {
     "$BOB_IDENTITY_NAME" \
     "$wicpId" \
     "$marketplaceId" \
-    "1_200"
+    "600"
   [ "$DEBUG" == 1 ] && echo $?
 
   depositFungible \
     "$BOB_IDENTITY_NAME" \
     "$wicpId" \
     "$marketplaceId" \
-    "1_200" 
+    "600" 
   [ "$DEBUG" == 1 ] && echo $?
 
   makeOffer \

--- a/.scripts/healthcheck.sh
+++ b/.scripts/healthcheck.sh
@@ -465,13 +465,6 @@ accept_offer() {
     "600"
   [ "$DEBUG" == 1 ] && echo $?
 
-  depositFungible \
-    "$BOB_IDENTITY_NAME" \
-    "$wicpId" \
-    "$marketplaceId" \
-    "600" 
-  [ "$DEBUG" == 1 ] && echo $?
-
   makeOffer \
     "$BOB_IDENTITY_NAME" \
     "Bob" \
@@ -508,6 +501,14 @@ accept_offer() {
     "$nft_token_id_for_alice" \
     "$BOB_PRINCIPAL_ID"
   [ "$DEBUG" == 1 ] && echo $?
+
+  echo "balance of bob"
+
+  dfx canister call marketplace serviceBalanceOf "(principal \"$(dfx --identity $BOB_IDENTITY_NAME identity get-principal)\")"
+
+  echo "balance of alice"
+
+  dfx canister call marketplace serviceBalanceOf "(principal \"$(dfx --identity $ALICE_IDENTITY_NAME identity get-principal)\")"
 
   echo "starting crowns canister to test withdraw from balance..."
 

--- a/marketplace/marketplace.did
+++ b/marketplace/marketplace.did
@@ -40,6 +40,7 @@ type MPApiError = variant {
   InvalidListing;
   TransferNonFungibleError;
   Unauthorized;
+  InsufficientFungibleAllowance;
   TransferFungibleError;
   InvalidOffer;
   Other : text;

--- a/marketplace/marketplace.did
+++ b/marketplace/marketplace.did
@@ -1,5 +1,30 @@
+type BalanceMetadata = record {
+  owner : principal;
+  details : vec record { text; GenericValue };
+  token_type : text;
+  standard : text;
+  contractId : principal;
+};
 type FungibleBalance = record { locked : nat; amount : nat };
 type FungibleStandard = variant { DIP20 };
+type GenericValue = variant {
+  Nat64Content : nat64;
+  Nat32Content : nat32;
+  BoolContent : bool;
+  Nat8Content : nat8;
+  Int64Content : int64;
+  IntContent : int;
+  NatContent : nat;
+  Nat16Content : nat16;
+  Int32Content : int32;
+  Int8Content : int8;
+  FloatContent : float64;
+  Int16Content : int16;
+  BlobContent : vec nat8;
+  NestedContent : vec record { text; GenericValue };
+  Principal : principal;
+  TextContent : text;
+};
 type Listing = record {
   status : ListingStatus;
   direct_buy : bool;
@@ -71,6 +96,7 @@ service : (principal, principal) -> {
     ) query;
   makeListing : (bool, principal, nat64, nat) -> (Result);
   makeOffer : (principal, nat64, nat) -> (Result);
+  serviceBalanceOf : (principal) -> (vec BalanceMetadata) query;
   withdrawFungible : (principal, FungibleStandard) -> (Result);
   withdrawNFT : (principal, nat64) -> (Result);
 }

--- a/marketplace/src/fungible_proxy.rs
+++ b/marketplace/src/fungible_proxy.rs
@@ -43,6 +43,19 @@ pub async fn balance_of_fungible(
     }
 }
 
+pub async fn allowance_fungible(
+    contract: &Principal,
+    marketplace_canister_id: &Principal,
+    principal: &Principal,
+    fungible_canister_standard: FungibleStandard,
+) -> NatResult {
+    match fungible_canister_standard {
+        FungibleStandard::DIP20 => {
+            Dip20Proxy::allowance(contract, principal, marketplace_canister_id).await
+        }
+    }
+}
+
 pub(crate) struct Dip20Proxy {}
 
 impl Dip20Proxy {
@@ -77,6 +90,23 @@ impl Dip20Proxy {
             ic::call(*contract, "balanceOf", (*principal,)).await;
         call_res
             .map_err(|_| MPApiError::TransferFungibleError)
+            .map(|res| res.0)
+    }
+
+    pub async fn allowance(
+        contract: &Principal,
+        principal: &Principal,
+        marketplace_canister_id: &Principal,
+    ) -> NatResult {
+        let call_res: Result<(Nat,), (RejectionCode, String)> = ic::call(
+            *contract,
+            "allowance",
+            (*principal, *marketplace_canister_id),
+        )
+        .await;
+
+        call_res
+            .map_err(|_| MPApiError::InsufficientFungibleBalance)
             .map(|res| res.0)
     }
 }

--- a/marketplace/src/fungible_proxy.rs
+++ b/marketplace/src/fungible_proxy.rs
@@ -35,23 +35,23 @@ pub async fn transfer_fungible(
 
 pub async fn balance_of_fungible(
     contract: &Principal,
-    principal: &Principal,
+    owner: &Principal,
     fungible_canister_standard: FungibleStandard,
 ) -> NatResult {
     match fungible_canister_standard {
-        FungibleStandard::DIP20 => Dip20Proxy::balance_of(contract, principal).await,
+        FungibleStandard::DIP20 => Dip20Proxy::balance_of(contract, owner).await,
     }
 }
 
 pub async fn allowance_fungible(
     contract: &Principal,
-    marketplace_canister_id: &Principal,
-    principal: &Principal,
+    owner: &Principal,
+    spender: &Principal,
     fungible_canister_standard: FungibleStandard,
 ) -> NatResult {
     match fungible_canister_standard {
         FungibleStandard::DIP20 => {
-            Dip20Proxy::allowance(contract, principal, marketplace_canister_id).await
+            Dip20Proxy::allowance(contract, owner, spender).await
         }
     }
 }
@@ -85,9 +85,9 @@ impl Dip20Proxy {
             .map(|res| convert_nat_to_u64(res).unwrap())
     }
 
-    pub async fn balance_of(contract: &Principal, principal: &Principal) -> NatResult {
+    pub async fn balance_of(contract: &Principal, owner: &Principal) -> NatResult {
         let call_res: Result<(Nat,), (RejectionCode, String)> =
-            ic::call(*contract, "balanceOf", (*principal,)).await;
+            ic::call(*contract, "balanceOf", (*owner,)).await;
         call_res
             .map_err(|_| MPApiError::TransferFungibleError)
             .map(|res| res.0)
@@ -95,13 +95,13 @@ impl Dip20Proxy {
 
     pub async fn allowance(
         contract: &Principal,
-        principal: &Principal,
-        marketplace_canister_id: &Principal,
+        owner: &Principal,
+        spender: &Principal,
     ) -> NatResult {
         let call_res: Result<(Nat,), (RejectionCode, String)> = ic::call(
             *contract,
             "allowance",
-            (*principal, *marketplace_canister_id),
+            (*owner, *spender),
         )
         .await;
 

--- a/marketplace/src/fungible_proxy.rs
+++ b/marketplace/src/fungible_proxy.rs
@@ -106,7 +106,7 @@ impl Dip20Proxy {
         .await;
 
         call_res
-            .map_err(|_| MPApiError::InsufficientFungibleBalance)
+            .map_err(|_| MPApiError::InsufficientFungibleAllowance)
             .map(|res| res.0)
     }
 }

--- a/marketplace/src/main.rs
+++ b/marketplace/src/main.rs
@@ -161,7 +161,7 @@ pub async fn make_offer(nft_canister_id: Principal, token_id: u64, price: Nat) -
     if allowance.is_err() {
         return Err(MPApiError::Other("Error calling allowance".to_string()));
     } else if allowance.ok().unwrap().clone() < price.clone() {
-        return Err(MPApiError::Other("Insufficient allowance".to_string()));
+        return Err(MPApiError::InsufficientFungibleAllowance);
     }
 
     // check wallet balance for token
@@ -283,7 +283,7 @@ pub async fn accept_offer(
     if allowance.is_err() {
         return Err(MPApiError::Other("Error calling allowance".to_string()));
     } else if allowance.ok().unwrap().clone() < offer.price.clone() {
-        return Err(MPApiError::Other("Insufficient allowance".to_string()));
+        return Err(MPApiError::InsufficientFungibleAllowance);
     }
 
     // check buyer wallet balance

--- a/marketplace/src/types.rs
+++ b/marketplace/src/types.rs
@@ -2,7 +2,7 @@ use crate::vendor_types::*;
 
 use cap_sdk::{insert, Event, IndefiniteEvent, TypedEvent};
 use ic_kit::{
-    candid::{CandidType, Deserialize, Nat},
+    candid::{CandidType, Deserialize, Int, Nat},
     Principal,
 };
 
@@ -134,10 +134,27 @@ pub enum FungibleStandard {
     DIP20,
 }
 
+impl FungibleStandard {
+    pub fn to_string(&self) -> String {
+        match self {
+            FungibleStandard::DIP20 => "DIP20".to_string(),
+        }
+    }
+}
+
 #[derive(Copy, Clone, CandidType, Deserialize)]
 pub enum NFTStandard {
     DIP721v2,
     EXT,
+}
+
+impl NFTStandard {
+    pub fn to_string(&self) -> String {
+        match self {
+            NFTStandard::DIP721v2 => "DIP721v2".to_string(),
+            NFTStandard::EXT => "EXT".to_string(),
+        }
+    }
 }
 
 #[derive(Default)]

--- a/marketplace/src/types.rs
+++ b/marketplace/src/types.rs
@@ -116,6 +116,7 @@ pub enum MPApiError {
     InvalidListing,
     InvalidOffer,
     InsufficientFungibleBalance,
+    InsufficientFungibleAllowance,
     InsufficientNonFungibleBalance,
     Unauthorized,
     NoDeposit,

--- a/marketplace/src/vendor_types.rs
+++ b/marketplace/src/vendor_types.rs
@@ -1,4 +1,38 @@
-use ic_kit::candid::{CandidType, Deserialize, Nat, Principal};
+use ic_kit::candid::{CandidType, Deserialize, Int, Nat, Principal};
+use std::collections::HashMap;
+
+// BEGIN ServiceBalance //
+
+#[derive(CandidType, Clone, Deserialize)]
+pub enum GenericValue {
+    BoolContent(bool),
+    TextContent(String),
+    BlobContent(Vec<u8>),
+    Principal(Principal),
+    Nat8Content(u8),
+    Nat16Content(u16),
+    Nat32Content(u32),
+    Nat64Content(u64),
+    NatContent(Nat),
+    Int8Content(i8),
+    Int16Content(i16),
+    Int32Content(i32),
+    Int64Content(i64),
+    IntContent(Int),
+    FloatContent(f64), // motoko only support f64
+    NestedContent(Vec<(String, GenericValue)>),
+}
+
+#[derive(CandidType, Clone, Deserialize)]
+pub struct BalanceMetadata {
+    pub owner: Principal,
+    pub contractId: Principal,
+    pub standard: String,
+    pub token_type: String,
+    pub details: HashMap<String, GenericValue>,
+}
+
+// END ServiceBalance //
 
 // BEGIN EXT //
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "services:start": "./.scripts/deploy-all-services.sh",
     "reset": "dfx stop && rm -rf .dfx && yarn cap:reset && yarn crowns:reset && yarn wicp:reset",
     "mock:generate-tokens": "./.scripts/mocks/generate-mocks.sh",
-    "devcheck": "./.scripts/devcheck.sh"
+    "devcheck": "watch ./.scripts/devcheck.sh marketplace/src"
   },
   "repository": {
     "type": "git",
@@ -36,3 +36,4 @@
   },
   "homepage": "https://github.com/Psychedelic/nft-marketplace#readme"
 }
+


### PR DESCRIPTION
## Why?

Offers should be permissionless and only withdraw from the buyers wallet at the time of transaction.

This also adds the `serviceBalanceOf(user: Principal)` interface, to have a single endpoint for all of a users assets held by marketplace 

## How?

we can do this safely because we always have a guarantee that MP will have nft at the time of transaction, so we can return with an error before the transaction proceeds. 

#### new acceptOffer logic:
1. check if nft has been deposited in marketplace, and the caller is the owner stored
2. check if marketplace has sufficient allowance for a buyer, then check if the buyer has a sufficient balance for the transaction
3. marketplace then transfers the total offer amount to itself, returning with error if it cannot deposit "just-in-time"
4. Fee is added to mkp balance for collection owner (we dont transfer to speed txn up, faster to just use balance, maybe we could have a function that runs on cron to trigger a withdraw for those collection owners automatically)
5. remainder is then sent to the seller, falling back to balance if unsuccessful

## Contribution checklist?

- [ ] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [x] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass
- [x] All tests pass

## Security checklist?

- [x] Injection has been prevented (parameterized queries, no eval or system calls)
- [x] Sensitive data has been identified and is being protected properly

## Demo?

Optionally, provide any screenshot, gif or small video.
