### PR TITLE
fix: nat type in healthcheck, allowance params were switched

### DIFF
--- a/.scripts/healthcheck.sh
+++ b/.scripts/healthcheck.sh
@@ -262,7 +262,7 @@ depositNFT() {
     --update $_marketplaceId depositNFT \
     "(
       principal \"$_nonFungibleContractAddress\",
-      $_token_id:nat64
+      $_token_id:nat
     )"
 }
 
@@ -279,7 +279,7 @@ withdrawNFT() {
     --update $_marketplaceId withdrawNFT \
     "(
       principal \"$_nonFungibleContractAddress\",
-      $_token_id:nat64
+      $_token_id:nat
     )"
 }
 
@@ -346,7 +346,7 @@ makeOffer() {
     canister call --update "$_marketplaceId" \
     makeOffer "(
       principal \"$_nonFungibleContractAddress\",
-      ($_token_id:nat64),
+      ($_token_id:nat),
       ($_offer_price:nat)
     )"
 }
@@ -421,7 +421,7 @@ acceptOffer() {
     call --update "$_marketplaceId" \
     acceptOffer "(
       principal \"$_nonFungibleContractAddress\",
-      $_token_id:nat64,
+      $_token_id:nat,
       principal \"$_buyerId\"
     )"
 }
@@ -439,7 +439,7 @@ directBuy() {
     --update $_marketplaceId directBuy \
     "(
       principal \"$nonFungibleContractAddress\",
-      $_token_id:nat64
+      $_token_id:nat
     )"
 }
 
@@ -608,23 +608,11 @@ run() {
     "$BOB_PRINCIPAL_ID" \
     "100_000_000"
   [ "$DEBUG" == 1 ] && echo $?
-  
-  allowancesForWICP \
-    "$wicpId" \
-    "$marketplaceId" \
-    "50_000_000"
-  [ "$DEBUG" == 1 ] && echo $?
 
   mintDip721 \
     "Alice" \
     "$ALICE_PRINCIPAL_ID" \
     "$nonFungibleContractAddress"
-  [ "$DEBUG" == 1 ] && echo $?
-
-  allowancesForDIP721 \
-    "$nonFungibleContractAddress" \
-    "$marketplaceId" \
-    "$nft_token_id_for_alice"
   [ "$DEBUG" == 1 ] && echo $?
 
   addCrownCollection \

--- a/marketplace/src/main.rs
+++ b/marketplace/src/main.rs
@@ -141,8 +141,8 @@ pub async fn make_offer(nft_canister_id: Principal, token_id: Nat, price: Nat) -
     // check if marketplace has allowance
     let allowance = allowance_fungible(
         &collection.fungible_canister_id,
-        &self_id,
         &buyer,
+        &self_id,
         collection.fungible_canister_standard.clone(),
     )
     .await;
@@ -268,8 +268,8 @@ pub async fn accept_offer(
     // check if marketplace has allowance
     let allowance = allowance_fungible(
         &collection.fungible_canister_id,
-        &self_id,
         &buyer,
+        &self_id,
         collection.fungible_canister_standard.clone(),
     )
     .await;


### PR DESCRIPTION
## Why?

Error in healthcheck using incorrect nat type
Error in fungible proxy allowance method, parameters are switched around

## How?


## Tickets?

- [Ticket 1](the-ticket-url-here)
- [Ticket 2](the-ticket-url-here)
- [Ticket 3](the-ticket-url-here)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] It does not break existing features (unless required)
- [ ] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [ ] All code formatting pass
- [ ] All lints pass
- [ ] All tests pass

## Security checklist?

- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] Sensitive data has been identified and is being protected properly

## Demo?

Optionally, provide any screenshot, gif or small video.
