### PR TITLE
fix: order of flows was reversed, so offer flow didn't have enough funds to complete

### DIFF
--- a/.scripts/healthcheck.sh
+++ b/.scripts/healthcheck.sh
@@ -631,9 +631,8 @@ run() {
     10 \
     0
   [ "$DEBUG" == 1 ] && echo $?
-
-  direct_buy $ALICE_IDENTITY_NAME $BOB_IDENTITY_NAME
-  accept_offer $BOB_IDENTITY_NAME $ALICE_IDENTITY_NAME
+  direct_buy $BOB_IDENTITY_NAME $ALICE_IDENTITY_NAME
+  accept_offer $ALICE_IDENTITY_NAME $BOB_IDENTITY_NAME
 
   echo "👍 Healthcheck completed!"
 


### PR DESCRIPTION
## Why?

healthcheck was giving errors

## How?

order of flows was reversed, so offer flow didn't have enough funds to complete

## Tickets?

- [Ticket 1](the-ticket-url-here)
- [Ticket 2](the-ticket-url-here)
- [Ticket 3](the-ticket-url-here)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] It does not break existing features (unless required)
- [ ] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [ ] All code formatting pass
- [ ] All lints pass
- [ ] All tests pass

## Security checklist?

- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] Sensitive data has been identified and is being protected properly

## Demo?

Optionally, provide any screenshot, gif or small video.
