### PR TITLE
feat: 🎸get offers by token id list

### DIFF
--- a/current_branch_cmds.sh
+++ b/current_branch_cmds.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# yarn marketplace:deploy $(dfx identity get-principal) $(cd ./cap && dfx canister id ic-history-router)
+
+dfx --identity marketplace.alice canister call --update qaa6y-5yaaa-aaaaa-aaafa-cai approve "( principal \"rdmx6-jaaaa-aaaaa-aaadq-cai\", 1_000_000_000:nat )"
+dfx --identity marketplace.alice canister call --update rdmx6-jaaaa-aaaaa-aaadq-cai makeOffer "( principal \"rkp4c-7iaaa-aaaaa-aaaca-cai\", 0:nat, 1242:nat )"
+dfx --identity marketplace.alice canister call --update rdmx6-jaaaa-aaaaa-aaadq-cai makeOffer "( principal \"rkp4c-7iaaa-aaaaa-aaaca-cai\", 1:nat, 1243:nat )"
+dfx canister call --update rdmx6-jaaaa-aaaaa-aaadq-cai getTokenOffers "( principal \"rkp4c-7iaaa-aaaaa-aaaca-cai\", principal \"$(dfx identity get-principal)\")"

--- a/marketplace/marketplace.did
+++ b/marketplace/marketplace.did
@@ -95,8 +95,8 @@ service : (principal, principal) -> {
         vec record { nat; vec record { principal; Offer } };
       },
     ) query;
-  getTokenOffers : (principal, nat) -> (
-    vec record { principal; Offer },
+  getTokenOffers : (principal, principal) -> (
+    vec record { principal; vec Offer },
   ) query;
   makeListing : (bool, principal, nat, nat) -> (Result);
   makeOffer : (principal, nat, nat) -> (Result);

--- a/marketplace/marketplace.did
+++ b/marketplace/marketplace.did
@@ -95,6 +95,9 @@ service : (principal, principal) -> {
         vec record { nat; vec record { principal; Offer } };
       },
     ) query;
+  getTokenOffers : (principal, nat) -> (
+    vec record { principal; Offer },
+  ) query;
   makeListing : (bool, principal, nat, nat) -> (Result);
   makeOffer : (principal, nat, nat) -> (Result);
   serviceBalanceOf : (principal) -> (vec BalanceMetadata) query;

--- a/marketplace/src/main.rs
+++ b/marketplace/src/main.rs
@@ -606,6 +606,23 @@ pub async fn get_all_offers() -> HashMap<Principal, HashMap<Nat, HashMap<Princip
     marketplace().alt_offers.clone()
 }
 
+#[query(name = "getTokenOffers")]
+#[candid_method(query, rename = "getTokenOffers")]
+pub async fn get_token_offers(nft_canister_id: Principal, token_id: Nat) -> HashMap<Principal, Offer> {
+    let allOffers = marketplace()
+        .alt_offers
+        .clone();
+    let offers = allOffers
+        .get(&nft_canister_id)
+        .and_then(|map| map.get(&token_id));
+
+    if let None = offers {
+        return HashMap::new();
+    };
+
+    return offers.unwrap().clone();
+}
+
 #[query(name = "getAllBalances")]
 #[candid_method(query, rename = "getAllBalances")]
 pub async fn get_all_balances() -> HashMap<(Principal, Principal), FungibleBalance> {

--- a/marketplace/src/main.rs
+++ b/marketplace/src/main.rs
@@ -10,7 +10,7 @@ use cap_sdk::{
     handshake, insert, DetailValue, Event, IndefiniteEvent, IndefiniteEventBuilder, TypedEvent,
 };
 use ic_kit::{
-    candid::{candid_method, encode_args, CandidType, Deserialize, Nat},
+    candid::{candid_method, encode_args, CandidType, Deserialize, Nat, export_service},
     ic,
     interfaces::{management, Method},
     macros::*,
@@ -1058,4 +1058,10 @@ fn main() {}
 fn main() {
     candid::export_service!();
     std::print!("{}", __export_service());
+}
+
+#[query(name = "__get_candid_interface_tmp_hack")]
+fn export_candid() -> String {
+    export_service!();
+    __export_service()
 }

--- a/marketplace/src/main.rs
+++ b/marketplace/src/main.rs
@@ -608,19 +608,78 @@ pub async fn get_all_offers() -> HashMap<Principal, HashMap<Nat, HashMap<Princip
 
 #[query(name = "getTokenOffers")]
 #[candid_method(query, rename = "getTokenOffers")]
-pub async fn get_token_offers(nft_canister_id: Principal, token_id: Nat) -> HashMap<Principal, Offer> {
-    let allOffers = marketplace()
+pub async fn get_token_offers(nft_canister_id: Principal, owner_principal: Principal) -> HashMap<Principal, Vec<Offer>> {
+    ic_cdk::println!("[debug] get_token_offers 1");
+
+    let all_offers = marketplace()
         .alt_offers
         .clone();
-    let offers = allOffers
-        .get(&nft_canister_id)
-        .and_then(|map| map.get(&token_id));
 
-    if let None = offers {
-        return HashMap::new();
-    };
+    ic_cdk::println!("[debug] get_token_offers 2");
+    
+    let nft_canister_offers = all_offers
+        .get(&nft_canister_id);
+    
+    ic_cdk::println!("[debug] get_token_offers 3");
+    
+    let mut owned_token_offers: HashMap<Principal, Vec<Offer>> = HashMap::new();
 
-    return offers.unwrap().clone();
+    // let token_owner_result = owner_token_identifiers(
+    //     &nft_canister_id,
+    //     &owner_principal,
+    // )
+    // .await;
+
+    // if let Error = token_owner_result {
+    //     return HashMap::new();
+    // }
+
+    // let token_owner = token_owner_result.unwrap();
+
+    // if let None = token_owner {
+    //     return HashMap::new();
+    // }
+
+    // let owned_token_ids = token_owner
+    //     .unwrap()
+    //     .clone();
+
+    // TODO: Get the list from the nft canister
+    // by querying the DIP721 ownerTokenIdentifiers(arg: Principal)
+    // for the moment the token ids are hard-typed
+    let tk_a: Nat = Nat::from(0 as u8);
+    let tk_b: Nat = Nat::from(1 as u8);
+    let mut owned_token_ids: Vec<Nat> = vec![tk_a, tk_b];
+
+    for owned_token_id in owned_token_ids {
+        ic_cdk::println!("[debug] get_token_offers 4");
+
+        let has_token_offers = nft_canister_offers
+           .and_then(|map| map.get(&owned_token_id));
+
+        if let None = has_token_offers {
+            return HashMap::new();
+        }
+
+        let token_offers = has_token_offers
+           .unwrap()
+           .clone();
+
+        ic_cdk::println!("[debug] get_token_offers 5");
+
+        for key in token_offers.keys() {
+            let offer = token_offers.get(&key).unwrap().clone();
+
+            owned_token_offers
+                .entry(key.clone())
+                .or_default()
+                .push(offer);
+        }
+    }
+
+    ic_cdk::println!("[debug] get_token_offers 6");
+
+    return owned_token_offers;
 }
 
 #[query(name = "getAllBalances")]

--- a/marketplace/src/non_fungible_proxy.rs
+++ b/marketplace/src/non_fungible_proxy.rs
@@ -53,6 +53,13 @@ pub async fn owner_of_non_fungible(
     }
 }
 
+// pub async fn owner_token_identifiers(
+//     contract: &Principal,
+//     owner: &Principal,
+// ) -> Result<Option<Vec<Nat>>, MPApiError> {
+//     DIP721v2Proxy::owner_token_identifiers(contract, owner).await
+// }
+
 pub(crate) struct DIP721v2Proxy {}
 
 impl DIP721v2Proxy {
@@ -108,6 +115,19 @@ impl DIP721v2Proxy {
             .0
             .map_err(|_| MPApiError::TransferFungibleError)
     }
+
+    // pub async fn owner_token_identifiers(
+    //     contract: &Principal,
+    //     owner: &Principal,
+    // ) -> Result<Option<Vec<Nat>>, MPApiError> {
+    //     let call_res: Result<(Result<Option<Vec<Nat>>, NftError>,), (RejectionCode, String)> =
+    //         ic::call(*contract, "ownerTokenIdentifiers", (owner.clone(),)).await;
+
+    //     call_res
+    //         .map_err(|_| MPApiError::Other("Oops! Failed to get owner token identifiers".to_string()))?
+    //         .0
+    //         .map_err(|_| MPApiError::TransferFungibleError)
+    // }
 }
 
 pub(crate) struct EXTProxy {}


### PR DESCRIPTION
## Why?

The current get all tokens is not scalable, there should be a more user-specific method to provide the user with a small result, to reduce the footprint on each request e.g. by querying by the token contract and the token id as what the user owns (token ids) is a smaller set than the whole collection.

## How?

- Remove get all offers
- Implement get token offers, where query by token contract and user token id list to get a set
- Add get token offers to candid

## Demo?

Optionally, provide any screenshot, gif or small video.
