### PR TITLE
feat: getTokenOffers and getBuyerOffers endpoints

### DIFF
--- a/marketplace/marketplace.did
+++ b/marketplace/marketplace.did
@@ -98,7 +98,9 @@ service : (principal, principal) -> {
     ) query;
   getBuyerOffers : (principal, principal) -> (vec Offer) query;
   getFloor : (principal) -> (Result_1) query;
-  getTokenOffers : (principal, nat) -> (vec Offer) query;
+  getTokenOffers : (principal, vec nat) -> (
+      vec record { nat; vec Offer },
+    ) query;
   makeListing : (bool, principal, nat, nat) -> (Result);
   makeOffer : (principal, nat, nat) -> (Result);
   serviceBalanceOf : (principal) -> (vec BalanceMetadata) query;

--- a/marketplace/marketplace.did
+++ b/marketplace/marketplace.did
@@ -98,7 +98,7 @@ service : (principal, principal) -> {
     ) query;
   getBuyerOffers : (principal, principal) -> (vec Offer) query;
   getFloor : (principal) -> (Result_1) query;
-  getTokenOffers : (principal, nat) -> (vec record { principal; Offer }) query;
+  getTokenOffers : (principal, nat) -> (vec Offer) query;
   makeListing : (bool, principal, nat, nat) -> (Result);
   makeOffer : (principal, nat, nat) -> (Result);
   serviceBalanceOf : (principal) -> (vec BalanceMetadata) query;

--- a/marketplace/marketplace.did
+++ b/marketplace/marketplace.did
@@ -96,7 +96,9 @@ service : (principal, principal) -> {
         vec record { nat; vec record { principal; Offer } };
       },
     ) query;
+  getBuyerOffers : (principal, principal) -> (vec Offer) query;
   getFloor : (principal) -> (Result_1) query;
+  getTokenOffers : (principal, nat) -> (vec record { principal; Offer }) query;
   makeListing : (bool, principal, nat, nat) -> (Result);
   makeOffer : (principal, nat, nat) -> (Result);
   serviceBalanceOf : (principal) -> (vec BalanceMetadata) query;

--- a/marketplace/src/main.rs
+++ b/marketplace/src/main.rs
@@ -715,12 +715,12 @@ pub async fn get_all_offers() -> HashMap<Principal, HashMap<Nat, HashMap<Princip
 pub async fn get_token_offers(
     nft_canister_id: Principal,
     token_id: Nat,
-) -> HashMap<Principal, Offer> {
+) -> Vec<Offer> {
     marketplace()
         .offers
         .entry(nft_canister_id)
         .or_default()
-        .entry(token_id).or_default().clone()
+        .entry(token_id).or_default().values().cloned().collect()
 }
 
 #[query(name = getBuyerOffers)]

--- a/marketplace/src/types.rs
+++ b/marketplace/src/types.rs
@@ -103,11 +103,14 @@ pub struct TxLogEntry {
 
 #[derive(Default)]
 pub(crate) struct Marketplace {
-    // (collection, token): listing
+    // collection { token: { listing } }
     pub listings: HashMap<Principal, HashMap<Nat, Listing>>,
 
     // collection: { token: { principal: offer } }
     pub offers: HashMap<Principal, HashMap<Nat, HashMap<Principal, Offer>>>,
+
+    // user: (collection, token)
+    pub user_offers: HashMap<Principal, HashMap<Principal, Vec<Nat>>>,
 }
 
 #[derive(CandidType, Deserialize, Debug)]


### PR DESCRIPTION
## Why?

need endpoints for querying for offers made for a token, or offers made by a given buyer

## How?

 - new user_offers hashmap that stores the list of tokens a user has made the offer for, and a getBuyerOffers grabs all the offer objects for a given buyer and returns a vector
 - getTokenOffers returns a vec of offers made for a token

## Tickets?

- [Ticket 1](the-ticket-url-here)
- [Ticket 2](the-ticket-url-here)
- [Ticket 3](the-ticket-url-here)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] It does not break existing features (unless required)
- [ ] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [ ] All code formatting pass
- [ ] All lints pass
- [ ] All tests pass

## Security checklist?

- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] Sensitive data has been identified and is being protected properly

## Demo?

Optionally, provide any screenshot, gif or small video.
