### PR TITLE
fix: 🐛 accept offer, listing not required but if, remove

### DIFF
--- a/marketplace/src/main.rs
+++ b/marketplace/src/main.rs
@@ -626,12 +626,6 @@ pub async fn accept_offer(
         return Err(MPApiError::InvalidOfferStatus);
     }
 
-    let listings = mp.listings.entry(nft_canister_id).or_default();
-
-    let listing = listings
-        .get_mut(&token_id.clone())
-        .ok_or(MPApiError::InvalidListing)?;
-
     // check if the NFT is owned by the seller still
     let token_owner = owner_of_non_fungible(
         &nft_canister_id,
@@ -640,7 +634,8 @@ pub async fn accept_offer(
     )
     .await?;
 
-    if (token_owner.unwrap() != listing.payment_address) {
+    // check if caller/seller is the token owner
+    if (token_owner.unwrap() != seller) {
         return Err(MPApiError::Unauthorized);
     }
 
@@ -655,9 +650,6 @@ pub async fn accept_offer(
     if (token_operator.unwrap() != self_id) {
         return Err(MPApiError::InvalidOperator);
     }
-
-    // guarding agains reentrancy
-    listing.status = ListingStatus::Selling;
 
     // Auto deposit tokens
 

--- a/marketplace/src/main.rs
+++ b/marketplace/src/main.rs
@@ -660,7 +660,7 @@ pub async fn accept_offer(
 
     match token_operator {
         Some(principal) => {
-            if (token_operator.unwrap() != self_id) {
+            if (principal != self_id) {
                 return Err(MPApiError::InvalidOperator);
             }
         },
@@ -685,8 +685,10 @@ pub async fn accept_offer(
 
     if allowance.is_err() {
         return Err(MPApiError::Other("Error calling allowance".to_string()));
-    } else if allowance.ok().unwrap().clone() < offer_price.clone() {
-        return Err(MPApiError::InsufficientFungibleAllowance);
+    } else if let Some(has_allowance) = allowance.ok() {
+        if has_allowance < offer_price.clone() {
+            return Err(MPApiError::InsufficientFungibleAllowance);
+        }
     }
 
     // check buyer wallet balance
@@ -699,8 +701,10 @@ pub async fn accept_offer(
 
     if balance.is_err() {
         return Err(MPApiError::Other("Error calling balanceOf".to_string()));
-    } else if balance.ok().unwrap().clone() < offer_price.clone() {
-        return Err(MPApiError::InsufficientFungibleBalance);
+    } else if let Some(has_balance) = balance.ok() {
+        if has_balance < offer_price.clone() {
+            return Err(MPApiError::InsufficientFungibleBalance);
+        }
     }
 
     let owner_fee: Nat =


### PR DESCRIPTION
## Why?

On Accept offer, the NFT status does not seem to be required to be listed. Although the caller/seller, should indeed be checked, as the owner of the NFT. Although, in the case where the item is indeed listed, then it shall be removed.

## How?

- Modifies accept offer
- Removes listing handling
- Verify ownership of caller

