### PR TITLE
chore: include thumbnail metadata with mock-generate script

### DIFF
--- a/.scripts/healthcheck.sh
+++ b/.scripts/healthcheck.sh
@@ -126,7 +126,7 @@ mintDip721() {
           record {
             \"thumbnail\";
             variant {
-              \"TextContent\" = \"https://vzb3d-qyaaa-aaaam-qaaqq-cai.raw.ic0.app/thumbnail/$example_nft.png\"
+              \"TextContent\" = \"https://vzb3d-qyaaa-aaaam-qaaqq-cai.raw.ic0.app/thumbnails/$example_nft.png\"
             }
           };
         }

--- a/.scripts/mocks/generate-mocks.sh
+++ b/.scripts/mocks/generate-mocks.sh
@@ -29,9 +29,11 @@ generateMock() {
 
   crownsNftCanisterId="vlhm2-4iaaa-aaaam-qaatq-cai"
   filename=$(printf "%04d.mp4" "$token_index")
+  thumbnail=$(printf "thumbnails/%04d.png" "$token_index")
   crownsCertifiedAssetsA="vzb3d-qyaaa-aaaam-qaaqq-cai"
   crownsCertifiedAssetsB="vqcq7-gqaaa-aaaam-qaara-cai"
   assetUrl="https://$crownsCertifiedAssetsA.raw.ic0.app/$filename"
+  thumbnailUrl="https://$crownsCertifiedAssetsA.raw.ic0.app/$thumbnail"
 
   dfx canister --network ic call $crownsNftCanisterId getMetadataDip721 "($token_index:nat64)"
 
@@ -84,6 +86,12 @@ generateMock() {
           \"location\";
           variant {
             \"TextContent\" = \"$assetUrl\"
+          }
+        };
+        record {
+          \"thumbnail\";
+          variant {
+            \"TextContent\" = \"$thumbnailUrl\"
           }
         };
       }


### PR DESCRIPTION
## What

add metadata tag for thumbnail url in nft metadata

## Tickets?

- [Ticket 1](the-ticket-url-here)
- [Ticket 2](the-ticket-url-here)
- [Ticket 3](the-ticket-url-here)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] It does not break existing features (unless required)
- [ ] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [ ] All code formatting pass
- [ ] All lints pass
- [ ] All tests pass

## Security checklist?

- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] Sensitive data has been identified and is being protected properly

## Demo?

Optionally, provide any screenshot, gif or small video.
