### PR TITLE
feat: get collections hashmap

### DIFF
--- a/marketplace/marketplace.did
+++ b/marketplace/marketplace.did
@@ -2,9 +2,9 @@ type Collection = record {
   collection_fee : nat;
   creation_time : nat64;
   nft_canister_standard : NFTStandard;
-  total_market_cap : nat;
   owner : principal;
   collection_name : text;
+  fungible_volume : nat;
   fungible_canister_standard : FungibleStandard;
   fungible_canister_id : principal;
   nft_canister_id : principal;

--- a/marketplace/marketplace.did
+++ b/marketplace/marketplace.did
@@ -2,6 +2,7 @@ type Collection = record {
   collection_fee : nat;
   creation_time : nat64;
   nft_canister_standard : NFTStandard;
+  total_market_cap : nat;
   owner : principal;
   collection_name : text;
   fungible_canister_standard : FungibleStandard;

--- a/marketplace/src/main.rs
+++ b/marketplace/src/main.rs
@@ -95,13 +95,10 @@ pub async fn get_protocol_fee() -> Nat {
 
 #[query(name = "getCollections")]
 #[candid_method(query, rename = "getCollections")]
-pub async fn get_collections() -> Vec<Collection> {
+pub async fn get_collections() -> HashMap<Principal, Collection> {
     collections()
         .collections
         .clone()
-        .values()
-        .cloned()
-        .collect()
 }
 
 #[query(name = "getTokenListing")]

--- a/marketplace/src/main.rs
+++ b/marketplace/src/main.rs
@@ -673,6 +673,14 @@ pub async fn direct_buy(nft_canister_id: Principal, token_id: Nat) -> MPApiResul
     // remove listing
     listings.remove(&token_id.clone());
 
+    // update market cap for collection
+    collections()
+        .collections
+        .entry(nft_canister_id)
+        .and_modify(|collection_data| {
+            collection_data.total_market_cap = collection_data.total_market_cap.clone() + price.clone();
+        });
+
     capq()
         .insert_into_cap(
             IndefiniteEventBuilder::new()
@@ -917,6 +925,14 @@ pub async fn accept_offer(
             tokens.retain(|token| token != &token_id.clone());
         })
         .or_default();
+
+    // update market cap for collection
+    collections()
+        .collections
+        .entry(nft_canister_id)
+        .and_modify(|collection_data| {
+            collection_data.total_market_cap = collection_data.total_market_cap.clone() + offer_price.clone();
+        });
 
     capq()
         .insert_into_cap(

--- a/marketplace/src/main.rs
+++ b/marketplace/src/main.rs
@@ -235,9 +235,17 @@ pub async fn get_floor(nft_canister_id: Principal) -> NatResult {
 
 // UPDATE METHODS //
 
+/// Add a Collection
+/// - owner: principal id of the owner of the collection, collection fees will be distributed to this user
+/// - collection_fee: fee multiplied by e2, for precision. `2.50% fee` = `250:nat`
+/// - collection_name: string representing the collection name. Should match dab registry entry
+/// - nft_canister_id: principal of the nft collection
+/// - nft_canister_standard: nft standard, eg; `DIP721v2`
+/// - fungible_canister_id: principal of the fungible a collection is traded with
+/// - fungible_canister_standard: fungible standard, eg; `DIP20`
 #[update(name = "addCollection")]
 #[candid_method(update, rename = "addCollection")]
-fn add_collection(
+pub async fn add_collection(
     owner: Principal,
     collection_fee: Nat,
     creation_time: u64,
@@ -247,7 +255,9 @@ fn add_collection(
     fungible_canister_id: Principal,
     fungible_canister_standard: FungibleStandard,
 ) -> MPApiResult {
-    assert_eq!(ic::caller(), init_data().owner);
+    if let Err(e) = is_controller(&ic::caller()).await {
+        return Err(MPApiError::Unauthorized);
+    }
 
     collections().collections.insert(
         nft_canister_id,

--- a/marketplace/src/main.rs
+++ b/marketplace/src/main.rs
@@ -682,8 +682,8 @@ pub async fn direct_buy(nft_canister_id: Principal, token_id: Nat) -> MPApiResul
         .collections
         .entry(nft_canister_id)
         .and_modify(|collection_data| {
-            collection_data.total_market_cap =
-                collection_data.total_market_cap.clone() + price.clone();
+            collection_data.fungible_volume =
+                collection_data.fungible_volume.clone() + price.clone();
         });
 
     capq()
@@ -936,8 +936,8 @@ pub async fn accept_offer(
         .collections
         .entry(nft_canister_id)
         .and_modify(|collection_data| {
-            collection_data.total_market_cap =
-                collection_data.total_market_cap.clone() + offer_price.clone();
+            collection_data.fungible_volume =
+                collection_data.fungible_volume.clone() + offer_price.clone();
         });
 
     capq()

--- a/marketplace/src/main.rs
+++ b/marketplace/src/main.rs
@@ -70,7 +70,7 @@ pub fn process_fees(
     let mut total_fee: Nat = Nat::from(0);
 
     for (_, principal, fee) in fees {
-        // divide by 10000 to allow 2 digits of precision in the fee
+        // divide by 100 * 100 to allow 2 digits of precision in the fee percentage
         let amount: Nat = price.clone() * fee.clone() / Nat::from(10000);
 
         total_fee += amount.clone();
@@ -260,12 +260,16 @@ fn add_collection(
             nft_canister_standard,
             fungible_canister_id,
             fungible_canister_standard,
+            Nat::from(0),
         ),
     );
 
     Ok(())
 }
 
+/// Set Protocol Fee
+/// fee: e2 nat, for 2 decimals of precision
+/// so a 2.50% fee would be 250:nat
 #[update(name = "setProtocolFee")]
 #[candid_method(update, rename = "setProtocolFee")]
 fn set_protocol_fee(fee: Nat) -> MPApiResult {
@@ -678,7 +682,8 @@ pub async fn direct_buy(nft_canister_id: Principal, token_id: Nat) -> MPApiResul
         .collections
         .entry(nft_canister_id)
         .and_modify(|collection_data| {
-            collection_data.total_market_cap = collection_data.total_market_cap.clone() + price.clone();
+            collection_data.total_market_cap =
+                collection_data.total_market_cap.clone() + price.clone();
         });
 
     capq()
@@ -931,7 +936,8 @@ pub async fn accept_offer(
         .collections
         .entry(nft_canister_id)
         .and_modify(|collection_data| {
-            collection_data.total_market_cap = collection_data.total_market_cap.clone() + offer_price.clone();
+            collection_data.total_market_cap =
+                collection_data.total_market_cap.clone() + offer_price.clone();
         });
 
     capq()

--- a/marketplace/src/types.rs
+++ b/marketplace/src/types.rs
@@ -75,6 +75,7 @@ pub struct Collection {
     pub nft_canister_standard: NFTStandard,
     pub fungible_canister_id: Principal,
     pub fungible_canister_standard: FungibleStandard,
+    pub total_market_cap: Nat,
 }
 
 #[derive(Clone, CandidType, Default, Deserialize, new)]

--- a/marketplace/src/types.rs
+++ b/marketplace/src/types.rs
@@ -75,7 +75,7 @@ pub struct Collection {
     pub nft_canister_standard: NFTStandard,
     pub fungible_canister_id: Principal,
     pub fungible_canister_standard: FungibleStandard,
-    pub total_market_cap: Nat,
+    pub fungible_volume: Nat,
 }
 
 #[derive(Clone, CandidType, Default, Deserialize, new)]


### PR DESCRIPTION
## Why?

getCollections returns a vec, but a hashmap is better for FE to grab a specific collection from the returned data

## Tickets?

- [Ticket 1](the-ticket-url-here)
- [Ticket 2](the-ticket-url-here)
- [Ticket 3](the-ticket-url-here)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] It does not break existing features (unless required)
- [ ] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [ ] All code formatting pass
- [ ] All lints pass
- [ ] All tests pass

## Security checklist?

- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] Sensitive data has been identified and is being protected properly

## Demo?

Optionally, provide any screenshot, gif or small video.
