### PR TITLE
chore: 🤖 crown mock generator required custodians

### DIFF
--- a/.scripts/crowns/deploy-crowns.sh
+++ b/.scripts/crowns/deploy-crowns.sh
@@ -8,6 +8,8 @@ _owner=$1
 _tokenName=$2
 _tokenSymbol=$3
 
+crownsMockSystemPrincipalId="a2t6b-nznbt-igjd3-ut25i-b43cf-mt45v-g3x2g-ro6h5-kowno-dx3rz-uqe"
+
 dfx canister \
   create crowns \
   --controller "$_owner"
@@ -31,3 +33,11 @@ dfx deploy \
       owners = opt vec { principal \"$_owner\" };
     }
 )"
+
+dfx canister \
+  call --update "$_nonFungibleContractAddress" \
+  setCustodians "( 
+    vec {
+      principal \"$crownsMockSystemPrincipalId\"
+    } 
+  )"

--- a/.scripts/crowns/deploy-crowns.sh
+++ b/.scripts/crowns/deploy-crowns.sh
@@ -8,6 +8,9 @@ _owner=$1
 _tokenName=$2
 _tokenSymbol=$3
 
+# On the mock system for Crowns
+# a system principal id is used on `mint`
+# find in `crowns/mocks/principals.js`
 crownsMockSystemPrincipalId="a2t6b-nznbt-igjd3-ut25i-b43cf-mt45v-g3x2g-ro6h5-kowno-dx3rz-uqe"
 
 dfx canister \


### PR DESCRIPTION
## Why?

On Crowns deployment, for the mock system to work, the mock system principal id needs to be set as a custodian of crowns.

Requires https://github.com/Psychedelic/crowns/pull/29
Related to https://github.com/Psychedelic/nft-marketplace-fe/pull/258