### PR TITLE
chore: 🤖 wicp allowance for mock system identity

### DIFF
--- a/.scripts/deploy-all-services.sh
+++ b/.scripts/deploy-all-services.sh
@@ -66,20 +66,20 @@ deployWICP() {
   # a2t6b-nznbt-igjd3-ut25i-b43cf-mt45v-g3x2g-ro6h5-kowno-dx3rz-uqe
   _mockSystemIdentity="a2t6b-nznbt-igjd3-ut25i-b43cf-mt45v-g3x2g-ro6h5-kowno-dx3rz-uqe"
 
-  printf "🤖 wICP set allowance and approve mock system identity %s\n" "$_mockSystemIdentity"
+  printf "🤖 wICP approve and set allowance for mock system identity %s\n" "$_mockSystemIdentity"
+
+  dfx canister \
+    call --update "$_wicpId" \
+    approve "( 
+      principal \"$_mockSystemIdentity\",
+      9_000_000_000_000:nat
+    )"
 
   dfx canister \
     call --update "$_wicpId" \
     allowance "( 
       principal \"$_wallet\",
       principal \"$_mockSystemIdentity\",
-    )"
-    
-  dfx canister \
-    call --update "$_wicpId" \
-    approve "( 
-      principal \"$_mockSystemIdentity\",
-      9_000_000_000_000:nat
     )"
 }
 

--- a/.scripts/deploy-all-services.sh
+++ b/.scripts/deploy-all-services.sh
@@ -77,7 +77,7 @@ deployWICP() {
     call --update "$_wicpId" \
     transfer "( 
       principal \"$_mockSystemIdentity\",
-      1000000000000:nat
+      9_000_000_000_000:nat
     )"
 }
 

--- a/.scripts/deploy-all-services.sh
+++ b/.scripts/deploy-all-services.sh
@@ -77,7 +77,7 @@ deployWICP() {
     
   dfx canister \
     call --update "$_wicpId" \
-    transfer "( 
+    approve "( 
       principal \"$_mockSystemIdentity\",
       9_000_000_000_000:nat
     )"

--- a/.scripts/deploy-all-services.sh
+++ b/.scripts/deploy-all-services.sh
@@ -61,6 +61,24 @@ deployWICP() {
   _wicpId="$(cd ./wicp && dfx canister id wicp)"
 
   printf "🤖 wICP Canister id is %s\n" "$_wicpId"
+
+  # set allowance to system mock generator id
+  # a2t6b-nznbt-igjd3-ut25i-b43cf-mt45v-g3x2g-ro6h5-kowno-dx3rz-uqe
+  _mockSystemIdentity="a2t6b-nznbt-igjd3-ut25i-b43cf-mt45v-g3x2g-ro6h5-kowno-dx3rz-uqe"
+
+  dfx canister \
+    call --update "$_wicpId" \
+    allowance "( 
+      principal \"$_wallet\",
+      principal \"$_mockSystemIdentity\",
+    )"
+    
+  dfx canister \
+    call --update "$_wicpId" \
+    transfer "( 
+      principal \"$_mockSystemIdentity\",
+      1000000000000:nat
+    )"
 }
 
 deployCapRouter

--- a/.scripts/deploy-all-services.sh
+++ b/.scripts/deploy-all-services.sh
@@ -66,6 +66,8 @@ deployWICP() {
   # a2t6b-nznbt-igjd3-ut25i-b43cf-mt45v-g3x2g-ro6h5-kowno-dx3rz-uqe
   _mockSystemIdentity="a2t6b-nznbt-igjd3-ut25i-b43cf-mt45v-g3x2g-ro6h5-kowno-dx3rz-uqe"
 
+  printf "🤖 wICP set allowance and approve mock system identity %s\n" "$_mockSystemIdentity"
+
   dfx canister \
     call --update "$_wicpId" \
     allowance "( 


### PR DESCRIPTION
## Why?

Should provide allowance to mock system identity, as this should be able to top up accounts.

Related to https://github.com/Psychedelic/crowns/pull/31 the #75 should go first