### PR TITLE
fix: 🐛 on mocking, topup system user instead of allowance and approval for wicp

### DIFF
--- a/.scripts/deploy-all-services.sh
+++ b/.scripts/deploy-all-services.sh
@@ -66,21 +66,14 @@ deployWICP() {
   # a2t6b-nznbt-igjd3-ut25i-b43cf-mt45v-g3x2g-ro6h5-kowno-dx3rz-uqe
   _mockSystemIdentity="a2t6b-nznbt-igjd3-ut25i-b43cf-mt45v-g3x2g-ro6h5-kowno-dx3rz-uqe"
 
-  printf "🤖 wICP approve and set allowance for mock system identity %s\n" "$_mockSystemIdentity"
+  printf "🤖 wICP topup for mock system identity %s\n" "$_mockSystemIdentity"
 
   dfx canister \
     call --update "$_wicpId" \
-    approve "( 
+    transfer "( 
       principal \"$_mockSystemIdentity\",
-      9_000_000_000_000:nat
-    )"
-
-  dfx canister \
-    call --update "$_wicpId" \
-    allowance "( 
-      principal \"$_wallet\",
-      principal \"$_mockSystemIdentity\",
-    )"
+      9_000_000_000_000:nat,
+    )"  
 }
 
 deployCapRouter


### PR DESCRIPTION
## Why?

For some reason the allowance and approve is not working on latest, so instead topup wicp for the system user used for mock generation.
