### PR TITLE
feat: production canister and cover verification

### DIFF
--- a/canister_ids.json
+++ b/canister_ids.json
@@ -1,6 +1,7 @@
 {
   "marketplace": {
-    "ic": "o3ios-jaaaa-aaaag-qakqq-cai",
-    "fleek-testnet": "yva2f-aiaaa-aaaaa-aabqa-cai"
+    "test": "o3ios-jaaaa-aaaag-qakqq-cai",
+    "fleek-testnet": "yva2f-aiaaa-aaaaa-aabqa-cai",
+    "ic": "getti-aiaaa-aaaah-abkkq-cai"
   }
 }

--- a/canister_ids.json
+++ b/canister_ids.json
@@ -1,7 +1,8 @@
 {
   "marketplace": {
-    "test": "o3ios-jaaaa-aaaag-qakqq-cai",
-    "fleek-testnet": "yva2f-aiaaa-aaaaa-aabqa-cai",
     "ic": "getti-aiaaa-aaaah-abkkq-cai"
+  },
+  "marketplace-test": {
+  	"ic": "o3ios-jaaaa-aaaag-qakqq-cai"
   }
 }

--- a/cover.json
+++ b/cover.json
@@ -1,13 +1,13 @@
 {
   "ownerId": "ffuck-kxghi-gyvia-r5htr-246cy-acq5u-2tdgd-avtvf-jyqbt-xtmf7-cae",
-  "canisterId": "o3ios-jaaaa-aaaag-qakqq-cai",
+  "canisterId": "getti-aiaaa-aaaah-abkkq-cai",
   "canisterName": "marketplace",
   "repoUrl": "psychedelic/nft-marketplace",
-  "commitHash": "8727f1cd44de699e7f0d7065b8f64c814a0681c9",
-  "rustVersion": "1.60.0",
+  "commitHash": "0e13f4dba9e729152a7591d21067bd3ffe394079",
+  "rustVersion": "1.61.0",
   "dfxVersion": "0.9.3",
   "optimizeCount": 0,
   "publicKey": "0488bb751d43a89a22e41e6966d1bd6d9d018d0dcec76d4d553436b2928be46426385cf69446eb02b3248686ed116cfa06d76323577224b042076bf53af9f3b67a",
-  "signature": "dde222855c32d7463ac35ebe063177657750d6e7c2d5426ca9b569bc0f0941e218bf3e2c804211fc35764a0352d45f65c898de56925a90bbcd0a5bed2482191f",
-  "timestamp": 1654144652978
+  "signature": "8e43ba129d9d306faa5fe2e29790426ddb76fde2e7f79cd7c3bce7eb7a3140a838411c9d1e067747ec5e989018858f1e72d585ef0a2191085a60b7dccbc91650",
+  "timestamp": 1654638999144
 }

--- a/dfx.json
+++ b/dfx.json
@@ -46,6 +46,9 @@
       "bind": "127.0.0.1:8000",
       "type": "ephemeral"
     },
+    "test": {
+      "bind": "ic0.app"
+    },
     "fleek-testnet": {
       "bind": "34.216.56.80:8080"
     }

--- a/dfx.json
+++ b/dfx.json
@@ -34,6 +34,11 @@
       "package": "marketplace",
       "candid": "marketplace/marketplace.did",
       "type": "rust"
+    },
+    "marketplace-test": {
+       "package": "marketplace",
+       "candid": "marketplace/marketplace.did",
+       "type": "rust"
     }
   },
   "defaults": {


### PR DESCRIPTION
Adds production marketplace canister id.

`getti-aiaaa-aaaah-abkkq-cai`
- The 1.0% protocol fee on every transaction is held by the canister itself under its own principal. We can add a withdraw method for custodians in the future, or leave it until we add dao.
- Initialized with production cap, crowns, and wicp
- I am also setting the 2.5% crowns collection fee (creator royalty fee) to deposit under the marketplace cansiter id 
```
$ dfx canister --network ic install marketplace --argument '(principal "getti-aiaaa-aaaah-abkkq-cai", 100:nat, principal "lj532-6iaaa-aaaah-qcc7a-cai")'
Installing code for canister marketplace, with canister_id getti-aiaaa-aaaah-abkkq-cai


$ dfx canister --network ic call marketplace addCollection '(
  principal "getti-aiaaa-aaaah-abkkq-cai",
  250:nat,
  1638248400:nat64,
  "Crowns",
  principal "vlhm2-4iaaa-aaaam-qaatq-cai",
  variant {DIP721v2},
  principal "utozz-siaaa-aaaam-qaaxq-cai",
  variant {DIP20},
)' 
(variant { Ok })
```
controllers:
```
ossian - ffuck-kxghi-gyvia-r5htr-246cy-acq5u-2tdgd-avtvf-jyqbt-xtmf7-cae
helder - 6vj5p-imd5n-7gtwg-fskuc-bvuqy-65j54-xxdqw-gxikv-rkw4u-ocrmb-dqe
scott - j3dqd-46f74-s45g5-yt6qa-c5vyq-4zv7t-y4iie-omikc-cjngg-olpgg-rqe
janison - m3ry7-2jumh-ojsy6-fij7x-xnsrx-6v5ca-v2z76-fn2xu-skkxm-v77mj-uae
```