### PR TITLE
refactor: dip721 error handling and inter canister optimizations

### DIFF
--- a/.scripts/marketplace/deploy-marketplace.sh
+++ b/.scripts/marketplace/deploy-marketplace.sh
@@ -24,6 +24,6 @@ dfx deploy \
   marketplace --argument "(
     principal \"$_owner\",
     $_protocol_fee:nat,
-    principal \"$_icHistoryRouter\",
+    opt principal \"$_icHistoryRouter\",
   )" \
   $4

--- a/marketplace/marketplace.did
+++ b/marketplace/marketplace.did
@@ -10,6 +10,24 @@ type Collection = record {
   nft_canister_id : principal;
 };
 type FungibleStandard = variant { DIP20 };
+type GenericValue = variant {
+  Nat64Content : nat64;
+  Nat32Content : nat32;
+  BoolContent : bool;
+  Nat8Content : nat8;
+  Int64Content : int64;
+  IntContent : int;
+  NatContent : nat;
+  Nat16Content : nat16;
+  Int32Content : int32;
+  Int8Content : int8;
+  FloatContent : float64;
+  Int16Content : int16;
+  BlobContent : vec nat8;
+  NestedContent : Vec;
+  Principal : principal;
+  TextContent : text;
+};
 type Listing = record {
   fee : vec record { text; principal; nat };
   status : ListingStatus;
@@ -29,6 +47,7 @@ type MPApiError = variant {
   InsufficientFungibleAllowance;
   TransferFungibleError;
   InvalidOffer;
+  InvalidOwner;
   Other : text;
   InsufficientNonFungibleBalance;
   InvalidOfferStatus;
@@ -55,7 +74,44 @@ type OfferStatus = variant {
 type Result = variant { Ok; Err : MPApiError };
 type Result_1 = variant { Ok : nat; Err : MPApiError };
 type Result_2 = variant { Ok : Listing; Err : MPApiError };
-service : (principal, nat, principal) -> {
+type Result_3 = variant { Ok : TokenMetadata; Err : MPApiError };
+type TokenMetadata = record {
+  transferred_at : opt nat64;
+  transferred_by : opt principal;
+  owner : opt principal;
+  operator : opt principal;
+  approved_at : opt nat64;
+  approved_by : opt principal;
+  properties : vec record { text; GenericValue };
+  is_burned : bool;
+  token_identifier : nat;
+  burned_at : opt nat64;
+  burned_by : opt principal;
+  minted_at : nat64;
+  minted_by : principal;
+};
+type Vec = vec record {
+  text;
+  variant {
+    Nat64Content : nat64;
+    Nat32Content : nat32;
+    BoolContent : bool;
+    Nat8Content : nat8;
+    Int64Content : int64;
+    IntContent : int;
+    NatContent : nat;
+    Nat16Content : nat16;
+    Int32Content : int32;
+    Int8Content : int8;
+    FloatContent : float64;
+    Int16Content : int16;
+    BlobContent : vec nat8;
+    NestedContent : Vec;
+    Principal : principal;
+    TextContent : text;
+  };
+};
+service : (principal, nat, opt principal) -> {
   acceptOffer : (principal, nat, principal) -> (Result);
   addCollection : (
       principal,
@@ -89,5 +145,6 @@ service : (principal, nat, principal) -> {
   makeOffer : (principal, nat, nat) -> (Result);
   rustToolchainInfo : () -> (text) query;
   setProtocolFee : (nat) -> (Result);
+  test : (principal, nat) -> (Result_3);
   withdrawFungible : (principal, FungibleStandard) -> (Result);
 }

--- a/marketplace/src/fungible_proxy.rs
+++ b/marketplace/src/fungible_proxy.rs
@@ -17,7 +17,7 @@ pub async fn transfer_from_fungible(
     amount: &Nat,
     contract: &Principal,
     fungible_canister_standard: FungibleStandard,
-) -> U64Result {
+) -> NatResult {
     match fungible_canister_standard {
         FungibleStandard::DIP20 => Dip20Proxy::transfer_from(from, to, amount, contract).await,
     }
@@ -62,15 +62,14 @@ impl Dip20Proxy {
         to: &Principal,
         amount: &Nat,
         contract: &Principal,
-    ) -> U64Result {
+    ) -> NatResult {
         let call_res: Result<(TxReceipt,), (RejectionCode, String)> =
             ic::call(*contract, "transferFrom", (*from, *to, amount.clone())).await;
 
         call_res
-            .map_err(|_| MPApiError::TransferFungibleError)?
+            .map_err(|err| MPApiError::TransferFromFungibleError(format!("{:?}", err)))?
             .0
-            .map_err(|_| MPApiError::TransferFungibleError)
-            .map(|res| convert_nat_to_u64(res).unwrap())
+            .map_err(|err| MPApiError::TransferFromFungibleError(format!("{:?}", err)))
     }
 
     pub async fn transfer(to: &Principal, amount: &Nat, contract: &Principal) -> U64Result {

--- a/marketplace/src/fungible_proxy.rs
+++ b/marketplace/src/fungible_proxy.rs
@@ -27,7 +27,7 @@ pub async fn transfer_fungible(
     amount: &Nat,
     contract: &Principal,
     fungible_canister_standard: FungibleStandard,
-) -> U64Result {
+) -> NatResult {
     match fungible_canister_standard {
         FungibleStandard::DIP20 => Dip20Proxy::transfer(to, amount, contract).await,
     }
@@ -72,14 +72,13 @@ impl Dip20Proxy {
             .map_err(|err| MPApiError::TransferFromFungibleError(format!("{:?}", err)))
     }
 
-    pub async fn transfer(to: &Principal, amount: &Nat, contract: &Principal) -> U64Result {
+    pub async fn transfer(to: &Principal, amount: &Nat, contract: &Principal) -> NatResult {
         let call_res: Result<(TxReceipt,), (RejectionCode, String)> =
             ic::call(*contract, "transfer", (*to, amount.clone())).await;
         call_res
             .map_err(|_| MPApiError::TransferFungibleError)?
             .0
             .map_err(|_| MPApiError::TransferFungibleError)
-            .map(|res| convert_nat_to_u64(res).unwrap())
     }
 
     pub async fn balance_of(contract: &Principal, owner: &Principal) -> NatResult {

--- a/marketplace/src/main.rs
+++ b/marketplace/src/main.rs
@@ -603,7 +603,7 @@ pub async fn direct_buy(nft_canister_id: Principal, token_id: Nat) -> MPApiResul
         Ok(metadata) => {
             match metadata.owner {
                 Some(principal) => {
-                    // we only care if mp is the operator, disregard current owner
+                    // we only care if mp is the operator, disregard current owner/listing
                     token_owner = principal;
                 }
                 None => return Err(MPApiError::InvalidOwner),
@@ -636,7 +636,7 @@ pub async fn direct_buy(nft_canister_id: Principal, token_id: Nat) -> MPApiResul
 
     // Successfully auto deposited fungibles, transfer the nft from marketplace to the buyer
     match transfer_from_non_fungible(
-        &listing.seller,                  // from
+        &token_owner,                     // from
         &buyer,                           // to
         &token_id,                        // nft id
         &nft_canister_id,                 // contract
@@ -674,7 +674,7 @@ buyer, nft_canister_id, token_id, e,
 
     // transfer the funds from the MP to the seller, or
     if transfer_fungible(
-        &listing.seller,
+        &token_owner,
         &(listing.price.clone() - total_fees.clone()),
         &collection.fungible_canister_id,
         collection.fungible_canister_standard.clone(),

--- a/marketplace/src/main.rs
+++ b/marketplace/src/main.rs
@@ -558,14 +558,6 @@ pub async fn make_offer(nft_canister_id: Principal, token_id: Nat, price: Nat) -
 
     Ok(())
 }
-//r7inp-6aaaa-aaaaa-aaabq-cai
-#[update]
-#[candid_method(update)]
-pub async fn test(nft_canister_id: Principal, token_id: Nat) -> Result<TokenMetadata, MPApiError> {
-    let resp = DIP721v2Proxy::token_metadata(&token_id.clone(), &nft_canister_id).await;
-
-    resp
-}
 
 /// Direct buy a nft that has been listed
 ///

--- a/marketplace/src/main.rs
+++ b/marketplace/src/main.rs
@@ -941,10 +941,7 @@ seller, nft_canister_id, token_id, e,
                     DetailValue::Principal(nft_canister_id),
                 ),
                 ("buyer".into(), DetailValue::Principal(buyer)),
-                (
-                    "seller".into(),
-                    DetailValue::Principal(token_owner.unwrap()),
-                ),
+                ("seller".into(), DetailValue::Principal(seller)),
                 (
                     "price".into(),
                     DetailValue::U64(convert_nat_to_u64(offer_price.clone()).unwrap()),

--- a/marketplace/src/main.rs
+++ b/marketplace/src/main.rs
@@ -33,13 +33,13 @@ mod vendor_types;
 
 #[init]
 #[candid_method(init)]
-pub fn init(owner: Principal, protocol_fee: Nat, cap: Principal) {
+pub fn init(owner: Principal, protocol_fee: Nat, cap: Option<Principal>) {
     ic_kit::ic::store(InitData {
         cap,
         owner,
         protocol_fee,
     });
-    handshake(1_000_000_000_000, Some(cap));
+    handshake(1_000_000_000_000, cap);
 }
 
 // cover metadata
@@ -558,6 +558,14 @@ pub async fn make_offer(nft_canister_id: Principal, token_id: Nat, price: Nat) -
 
     Ok(())
 }
+//r7inp-6aaaa-aaaaa-aaabq-cai
+#[update]
+#[candid_method(update)]
+pub async fn test(nft_canister_id: Principal, token_id: Nat) -> Result<TokenMetadata, MPApiError> {
+    let resp = DIP721v2Proxy::token_metadata(&token_id.clone(), &nft_canister_id).await;
+
+    resp
+}
 
 /// Direct buy a nft that has been listed
 ///
@@ -596,73 +604,32 @@ pub async fn direct_buy(nft_canister_id: Principal, token_id: Nat) -> MPApiResul
         .get(&nft_canister_id)
         .ok_or(MPApiError::NonExistentCollection)?;
 
-    // check if the NFT is owned by the seller still
-    let token_owner = owner_of_non_fungible(
-        &nft_canister_id,
-        &token_id,
-        collection.nft_canister_standard,
-    )
-    .await?;
-
-    // check if caller/seller is the token owner
-    match token_owner {
-        Some(principal) => {
-            if (principal != listing.seller) {
-                return Err(MPApiError::Unauthorized);
+    // check token owner and operator
+    let token_owner: Principal;
+    let token_metadata = DIP721v2Proxy::token_metadata(&token_id.clone(), &nft_canister_id).await;
+    match token_metadata {
+        Ok(metadata) => {
+            match metadata.owner {
+                Some(principal) => {
+                    // we only care if mp is the operator, disregard current owner
+                    token_owner = principal;
+                }
+                None => return Err(MPApiError::InvalidOwner),
+            }
+            match metadata.operator {
+                Some(principal) => {
+                    if (principal != self_id) {
+                        return Err(MPApiError::InvalidOperator);
+                    }
+                }
+                None => return Err(MPApiError::InvalidOperator),
             }
         }
-        None => return Err(MPApiError::Unauthorized),
+        Err(e) => return Err(e),
     }
 
-    // check if mp is the operator still
-    let token_operator = operator_of_non_fungible(
-        &nft_canister_id,
-        &token_id,
-        collection.nft_canister_standard,
-    )
-    .await?;
-
-    // check if caller/seller is the token owner
-    match token_operator {
-        Some(principal) => {
-            if (principal != self_id) {
-                return Err(MPApiError::InvalidOperator);
-            }
-        }
-        None => return Err(MPApiError::InvalidOperator),
-    }
-
-    // Auto deposit tokens
-
-    // check if marketplace has allowance
-    let allowance = allowance_fungible(
-        &collection.fungible_canister_id,
-        &buyer,
-        &self_id,
-        collection.fungible_canister_standard.clone(),
-    )
-    .await
-    .map_err(|_| MPApiError::Other("Error calling allowance".to_string()))?;
-
-    if allowance.clone() < listing.price.clone() {
-        return Err(MPApiError::InsufficientFungibleAllowance);
-    }
-
-    // check buyer wallet balance
-    let balance = balance_of_fungible(
-        &collection.fungible_canister_id,
-        &buyer,
-        collection.fungible_canister_standard.clone(),
-    )
-    .await
-    .map_err(|_| MPApiError::Other("Error calling balanceOf".to_string()))?;
-
-    if balance.clone() < listing.price.clone() {
-        return Err(MPApiError::InsufficientFungibleBalance);
-    }
-
-    // auto deposit funds to mp from buyer
-    if transfer_from_fungible(
+    // Claim funds from user wallet
+    match transfer_from_fungible(
         &buyer,
         &self_id,
         &listing.price.clone(),
@@ -670,21 +637,13 @@ pub async fn direct_buy(nft_canister_id: Principal, token_id: Nat) -> MPApiResul
         collection.fungible_canister_standard.clone(),
     )
     .await
-    .is_err()
     {
-        balances().failed_tx_log_entries.push(TxLogEntry::new(
-            self_id.clone(),
-            listing.seller.clone(),
-            format!(
-                "accept_offer failed for user {} for contract {} for token id {}; transfer 2",
-                listing.seller, nft_canister_id, token_id,
-            ),
-        ));
-        return Err(MPApiError::TransferFungibleError);
+        Err(e) => return Err(e),
+        Ok(_) => {}
     }
 
     // Successfully auto deposited fungibles, transfer the nft from marketplace to the buyer
-    if transfer_from_non_fungible(
+    match transfer_from_non_fungible(
         &listing.seller,                  // from
         &buyer,                           // to
         &token_id,                        // nft id
@@ -692,24 +651,27 @@ pub async fn direct_buy(nft_canister_id: Principal, token_id: Nat) -> MPApiResul
         collection.nft_canister_standard, // nft type
     )
     .await
-    .is_err()
     {
-        // add deposited funds to buyer mp balance
-        *balances()
-            .balances
-            .entry((collection.fungible_canister_id, buyer))
-            .or_default() += listing.price.clone();
+        Err(e) => {
+            // error transferring nft
+            // add deposited funds to buyer mp balance (fallback to avoid extra transactions/time/cycles)
+            *balances()
+                .balances
+                .entry((collection.fungible_canister_id, buyer))
+                .or_default() += listing.price.clone();
 
-        balances().failed_tx_log_entries.push(TxLogEntry::new(
-            self_id.clone(),
-            buyer.clone(),
-            format!(
-        "accept_offer non fungible failed for user {} for contract {} for token id {}; transfer 1",
-        buyer, nft_canister_id, token_id,
-      ),
-        ));
+            balances().failed_tx_log_entries.push(TxLogEntry::new(
+                buyer.clone(),
+                token_owner.clone(),
+                format!(
+"direct buy non fungible failed for user {} for contract {} for token id {}; error: {:?}",
+buyer, nft_canister_id, token_id, e,
+),
+            ));
 
-        return Err(MPApiError::TransferNonFungibleError);
+            return Err(e);
+        }
+        Ok(_) => {}
     }
 
     let total_fees = process_fees(
@@ -717,7 +679,6 @@ pub async fn direct_buy(nft_canister_id: Principal, token_id: Nat) -> MPApiResul
         listing.price.clone(),
         listing.fee.clone(),
     );
-    ic::print(total_fees.to_string());
 
     // transfer the funds from the MP to the seller, or
     if transfer_fungible(
@@ -781,10 +742,7 @@ pub async fn direct_buy(nft_canister_id: Principal, token_id: Nat) -> MPApiResul
                     DetailValue::Principal(nft_canister_id),
                 ),
                 ("buyer".into(), DetailValue::Principal(buyer)),
-                (
-                    "seller".into(),
-                    DetailValue::Principal(token_owner.unwrap()),
-                ),
+                ("seller".into(), DetailValue::Principal(token_owner)),
                 (
                     "price".into(),
                     DetailValue::U64(convert_nat_to_u64(price.clone()).unwrap()),
@@ -837,94 +795,49 @@ pub async fn accept_offer(
 
     let listing = listings.get_mut(&token_id.clone());
 
-    // check if the NFT is owned by the seller still
-    let token_owner = owner_of_non_fungible(
-        &nft_canister_id,
-        &token_id,
-        collection.nft_canister_standard,
-    )
-    .await?;
-
-    // check if caller/seller is the token owner
-    match token_owner {
-        Some(principal) => {
-            if (principal != seller) {
-                return Err(MPApiError::Unauthorized);
+    // check token owner and operator
+    let token_owner: Principal;
+    let token_metadata = DIP721v2Proxy::token_metadata(&token_id.clone(), &nft_canister_id).await;
+    match token_metadata {
+        Ok(metadata) => {
+            match metadata.owner {
+                Some(principal) => {
+                    // error if caller is not the token owner
+                    if (principal != seller) {
+                        return Err(MPApiError::Unauthorized);
+                    }
+                    token_owner = principal;
+                }
+                None => return Err(MPApiError::InvalidOwner),
+            }
+            match metadata.operator {
+                Some(principal) => {
+                    if (principal != self_id) {
+                        return Err(MPApiError::InvalidOperator);
+                    }
+                }
+                None => return Err(MPApiError::InvalidOperator),
             }
         }
-        None => return Err(MPApiError::Unauthorized),
+        Err(e) => return Err(e),
     }
 
-    // check if mp is the operator still
-    let token_operator = operator_of_non_fungible(
-        &nft_canister_id,
-        &token_id,
-        collection.nft_canister_standard,
-    )
-    .await?;
-
-    match token_operator {
-        Some(principal) => {
-            if (principal != self_id) {
-                return Err(MPApiError::InvalidOperator);
-            }
-        }
-        None => return Err(MPApiError::InvalidOperator),
-    }
-
-    // Auto deposit tokens
-
-    // check if marketplace has allowance
-    let allowance = allowance_fungible(
-        &collection.fungible_canister_id,
+    // Claim funds from user wallet
+    match transfer_from_fungible(
         &buyer,
         &self_id,
-        collection.fungible_canister_standard.clone(),
-    )
-    .await
-    .map_err(|_| MPApiError::Other("Error calling allowance".to_string()))?;
-
-    if allowance.clone() < offer_price.clone() {
-        return Err(MPApiError::InsufficientFungibleAllowance);
-    }
-
-    // check buyer wallet balance
-    let balance = balance_of_fungible(
-        &collection.fungible_canister_id,
-        &buyer,
-        collection.fungible_canister_standard.clone(),
-    )
-    .await
-    .map_err(|_| MPApiError::Other("Error calling balanceOf".to_string()))?;
-
-    if balance.clone() < offer_price.clone() {
-        return Err(MPApiError::InsufficientFungibleBalance);
-    }
-
-    // auto deposit funds to mp from buyer
-    if transfer_from_fungible(
-        &buyer,
-        &self_id,
-        &offer_price.clone(),
+        &offer.price.clone(),
         &collection.fungible_canister_id,
         collection.fungible_canister_standard.clone(),
     )
     .await
-    .is_err()
     {
-        balances().failed_tx_log_entries.push(TxLogEntry::new(
-            self_id.clone(),
-            seller.clone(),
-            format!(
-                "accept_offer failed for user {} for contract {} for token id {}; transfer 2",
-                seller, nft_canister_id, token_id,
-            ),
-        ));
-        return Err(MPApiError::TransferFungibleError);
+        Err(e) => return Err(e),
+        Ok(_) => {}
     }
 
-    // Successfully auto deposited fungibles from buyer, transfer the nft from the seller to the buyer
-    if transfer_from_non_fungible(
+    // Successfully auto deposited fungibles, transfer the nft from marketplace to the buyer
+    match transfer_from_non_fungible(
         &seller,                          // from
         &buyer,                           // to
         &token_id,                        // nft id
@@ -932,24 +845,27 @@ pub async fn accept_offer(
         collection.nft_canister_standard, // nft type
     )
     .await
-    .is_err()
     {
-        // add deposited funds to buyer mp balance
-        *balances()
-            .balances
-            .entry((collection.fungible_canister_id, buyer))
-            .or_default() += offer_price.clone();
+        Err(e) => {
+            // error transferring nft
+            // add deposited funds to buyer mp balance (fallback to avoid extra transactions/time/cycles)
+            *balances()
+                .balances
+                .entry((collection.fungible_canister_id, buyer))
+                .or_default() += offer.price.clone();
 
-        balances().failed_tx_log_entries.push(TxLogEntry::new(
-            self_id.clone(),
-            buyer.clone(),
-            format!(
-        "accept_offer non fungible failed for user {} for contract {} for token id {}; transfer 1",
-        buyer, nft_canister_id, token_id,
-      ),
-        ));
+            balances().failed_tx_log_entries.push(TxLogEntry::new(
+                seller.clone(),
+                buyer.clone(),
+                format!(
+"accept offer non fungible failed for user {} for contract {} for token id {}; error: {:?}",
+seller, nft_canister_id, token_id, e,
+),
+            ));
 
-        return Err(MPApiError::TransferNonFungibleError);
+            return Err(e);
+        }
+        Ok(_) => {}
     }
 
     let total_fees = process_fees(

--- a/marketplace/src/non_fungible_proxy.rs
+++ b/marketplace/src/non_fungible_proxy.rs
@@ -88,9 +88,9 @@ impl DIP721v2Proxy {
         .await;
 
         call_res
-            .map_err(|err| MPApiError::Other(format!("{:?}", err)))?
+            .map_err(|err| MPApiError::TransferFromNonFungibleError(format!("{:?}", err)))?
             .0
-            .map_err(|err| MPApiError::Other(format!("{:?}", err)))
+            .map_err(|err| MPApiError::TransferFromNonFungibleError(format!("{:?}", err)))
     }
 
     pub async fn transfer(

--- a/marketplace/src/non_fungible_proxy.rs
+++ b/marketplace/src/non_fungible_proxy.rs
@@ -17,18 +17,10 @@ pub async fn transfer_from_non_fungible(
     token_id: &Nat,
     contract: &Principal,
     nft_type: NFTStandard,
-) -> U64Result {
+) -> NatResult {
     match nft_type {
         DIP721v2 => DIP721v2Proxy::transfer_from(from, to, token_id, contract).await,
-        EXT => {
-            EXTProxy::transfer_from(
-                from,
-                to,
-                &convert_nat_to_u64(token_id.clone()).unwrap(),
-                contract,
-            )
-            .await
-        }
+        EXT => unimplemented!(),
     }
 }
 
@@ -69,12 +61,25 @@ pub async fn operator_of_non_fungible(
 pub(crate) struct DIP721v2Proxy {}
 
 impl DIP721v2Proxy {
+    pub async fn token_metadata(
+        token_id: &Nat,
+        contract: &Principal,
+    ) -> Result<TokenMetadata, MPApiError> {
+        let call_res: Result<(Result<TokenMetadata, NftError>,), (RejectionCode, String)> =
+            ic::call(*contract, "tokenMetadata", (Nat::from(token_id.clone()),)).await;
+
+        call_res
+            .map_err(|err| MPApiError::Other(format!("{:?}", err)))?
+            .0
+            .map_err(|err| MPApiError::Other(format!("{:?}", err)))
+    }
+
     pub async fn transfer_from(
         from: &Principal,
         to: &Principal,
         token_id: &Nat,
         contract: &Principal,
-    ) -> U64Result {
+    ) -> NatResult {
         let call_res: Result<(Result<Nat, NftError>,), (RejectionCode, String)> = ic::call(
             *contract,
             "transferFrom",
@@ -83,10 +88,9 @@ impl DIP721v2Proxy {
         .await;
 
         call_res
-            .map_err(|_| MPApiError::Other("".to_string()))?
+            .map_err(|err| MPApiError::Other(format!("{:?}", err)))?
             .0
-            .map_err(|_| MPApiError::TransferFungibleError)
-            .map(|res| convert_nat_to_u64(res).unwrap())
+            .map_err(|err| MPApiError::Other(format!("{:?}", err)))
     }
 
     pub async fn transfer(
@@ -98,9 +102,9 @@ impl DIP721v2Proxy {
             ic::call(*contract, "transfer", (*to, Nat::from(token_id.clone()))).await;
 
         let res = call_res
-            .map_err(|_| MPApiError::Other("".to_string()))?
+            .map_err(|err| MPApiError::Other(format!("{:?}", err)))?
             .0
-            .map_err(|_| MPApiError::TransferFungibleError)
+            .map_err(|err| MPApiError::Other(format!("{:?}", err)))
             .map(|res| convert_nat_to_u64(res).unwrap());
 
         match &res {
@@ -117,9 +121,9 @@ impl DIP721v2Proxy {
             ic::call(*contract, "ownerOf", (Nat::from(token_id.clone()),)).await;
 
         call_res
-            .map_err(|_| MPApiError::Other("".to_string()))?
+            .map_err(|err| MPApiError::Other(format!("{:?}", err)))?
             .0
-            .map_err(|_| MPApiError::TransferFungibleError)
+            .map_err(|err| MPApiError::Other(format!("{:?}", err)))
     }
 
     pub async fn operator_of(
@@ -130,9 +134,9 @@ impl DIP721v2Proxy {
             ic::call(*contract, "operatorOf", (Nat::from(token_id.clone()),)).await;
 
         call_res
-            .map_err(|_| MPApiError::Other("".to_string()))?
+            .map_err(|err| MPApiError::Other(format!("{:?}", err)))?
             .0
-            .map_err(|e| MPApiError::Other("DIP721v2 Error".to_string()))
+            .map_err(|err| MPApiError::Other(format!("{:?}", err)))
     }
 }
 

--- a/marketplace/src/types.rs
+++ b/marketplace/src/types.rs
@@ -15,6 +15,8 @@ use derive_new::*;
 pub enum MPApiError {
     InvalidOperator,
     InvalidOwner,
+    TransferFromFungibleError(String),
+    TransferFromNonFungibleError(String),
 
     TransferFungibleError,
     TransferNonFungibleError,

--- a/marketplace/src/types.rs
+++ b/marketplace/src/types.rs
@@ -11,6 +11,27 @@ use std::collections::{HashMap, VecDeque};
 
 use derive_new::*;
 
+#[derive(CandidType, Deserialize, Debug)]
+pub enum MPApiError {
+    InvalidOperator,
+    InvalidOwner,
+
+    TransferFungibleError,
+    TransferNonFungibleError,
+    InvalidListingStatus,
+    InvalidOfferStatus,
+    InvalidListing,
+    InvalidOffer,
+    InsufficientFungibleBalance,
+    InsufficientFungibleAllowance,
+    InsufficientNonFungibleBalance,
+    Unauthorized,
+    NoDeposit,
+    CAPInsertionError,
+    NonExistentCollection,
+    Other(String),
+}
+
 #[derive(Clone, CandidType, Debug, Deserialize, Eq, PartialEq)]
 pub enum OfferStatus {
     Uninitialized,
@@ -29,7 +50,7 @@ pub enum ListingStatus {
 
 #[derive(CandidType, Clone, Deserialize)]
 pub struct InitData {
-    pub cap: Principal,
+    pub cap: Option<Principal>,
     pub owner: Principal,
     pub protocol_fee: Nat,
 }
@@ -108,25 +129,6 @@ pub(crate) struct Marketplace {
 
     // user: (collection, token)
     pub user_offers: HashMap<Principal, HashMap<Principal, Vec<Nat>>>,
-}
-
-#[derive(CandidType, Deserialize, Debug)]
-pub enum MPApiError {
-    TransferFungibleError,
-    TransferNonFungibleError,
-    InvalidListingStatus,
-    InvalidOfferStatus,
-    InvalidListing,
-    InvalidOffer,
-    InsufficientFungibleBalance,
-    InsufficientFungibleAllowance,
-    InsufficientNonFungibleBalance,
-    Unauthorized,
-    InvalidOperator,
-    NoDeposit,
-    CAPInsertionError,
-    NonExistentCollection,
-    Other(String),
 }
 
 pub type MPApiResult = Result<(), MPApiError>;

--- a/marketplace/src/vendor_types.rs
+++ b/marketplace/src/vendor_types.rs
@@ -1,9 +1,9 @@
 use ic_kit::candid::{CandidType, Deserialize, Int, Nat, Principal};
 use std::collections::HashMap;
 
-// BEGIN ServiceBalance //
+// BEGIN DIP721v2 //
 
-#[derive(CandidType, Clone, Deserialize)]
+#[derive(CandidType, Clone, Deserialize, Debug)]
 pub enum GenericValue {
     BoolContent(bool),
     TextContent(String),
@@ -22,6 +22,50 @@ pub enum GenericValue {
     FloatContent(f64), // motoko only support f64
     NestedContent(Vec<(String, GenericValue)>),
 }
+
+#[derive(CandidType, Clone, Deserialize, Debug)]
+pub struct TokenMetadata {
+    pub token_identifier: Nat,
+    pub owner: Option<Principal>,
+    pub operator: Option<Principal>,
+    pub is_burned: bool,
+    pub properties: Vec<(String, GenericValue)>,
+    pub minted_at: u64,
+    pub minted_by: Principal,
+    pub transferred_at: Option<u64>,
+    pub transferred_by: Option<Principal>,
+    pub approved_at: Option<u64>,
+    pub approved_by: Option<Principal>,
+    pub burned_at: Option<u64>,
+    pub burned_by: Option<Principal>,
+}
+
+#[derive(CandidType, Debug, Deserialize)]
+pub enum ApiError {
+    Unauthorized,
+    InvalidTokenId,
+    ZeroAddress,
+    Other,
+}
+
+#[derive(CandidType, Deserialize, Debug)]
+pub enum NftError {
+    UnauthorizedOwner,
+    UnauthorizedOperator,
+    OwnerNotFound,
+    OperatorNotFound,
+    TokenNotFound,
+    ExistedNFT,
+    SelfApprove,
+    SelfTransfer,
+    TxNotFound,
+    Other(String),
+}
+
+pub type TxReceiptDIP721v2 = Result<Nat, ApiError>;
+pub type OwnerResult = Result<Principal, NftError>;
+
+// END DIP721v2 //
 
 #[derive(CandidType, Clone, Deserialize)]
 pub struct BalanceMetadata {
@@ -73,35 +117,6 @@ pub enum TransferResponseErrors {
 pub type TransferResponse = Result<Balance, TransferResponseErrors>;
 
 // END EXT //
-
-// BEGIN DIP721v2 //
-
-#[derive(CandidType, Debug, Deserialize)]
-pub enum ApiError {
-    Unauthorized,
-    InvalidTokenId,
-    ZeroAddress,
-    Other,
-}
-
-#[derive(CandidType, Deserialize, Debug)]
-pub enum NftError {
-    UnauthorizedOwner,
-    UnauthorizedOperator,
-    OwnerNotFound,
-    OperatorNotFound,
-    TokenNotFound,
-    ExistedNFT,
-    SelfApprove,
-    SelfTransfer,
-    TxNotFound,
-    Other(String),
-}
-
-pub type TxReceiptDIP721v2 = Result<Nat, ApiError>;
-pub type OwnerResult = Result<Principal, NftError>;
-
-// END DIP721v2 //
 
 // BEGIN DIP20 //
 


### PR DESCRIPTION
## Why?

Dip721/dip20 errors are not handled verbosely, and we are performing many unnecessary inter-canister calls when we can depend on error from the call

## How?

- make cap init arg opt, defaults to mainnet cap canister if unspecified
- for canister calls, return error type Other(string) with exact error response
- for transfer_from, add new error types TransferFromFungibleError(string) and TransferFromNonFungibleError(string)
- added token_metadata to dip721v2proxy
- replace owner/operator call with single token_metadata call
- removed balance_of, allowance_of inter-canister calls, rely on error from transferFrom
- refine failed_tx_log to include error and proper text and ids
- update crowns submodule to remove guards to avoid unnecessary issues

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] It does not break existing features (unless required)
- [ ] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [ ] All code formatting pass
- [ ] All lints pass
- [ ] All tests pass

## Security checklist?

- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] Sensitive data has been identified and is being protected properly

## Demo?

Optionally, provide any screenshot, gif or small video.
