### PR TITLE
fix: 🐛 revert cap renaming for router

### DIFF
--- a/.scripts/deploy-all-services.sh
+++ b/.scripts/deploy-all-services.sh
@@ -6,7 +6,7 @@
 
 [ "$DEBUG" == 1 ] && set -x
 
-IC_HISTORY_ROUTER=$(cd ./cap && dfx canister id cap-router)
+IC_HISTORY_ROUTER=$(cd ./cap && dfx canister id ic-history-router)
 
 DEFAULT_PRINCIPAL_ID=$(dfx identity get-principal)
 
@@ -15,7 +15,7 @@ deployCapRouter() {
 
   yarn cap:start
 
-  _icHistoryRouter=$(cd ./cap && dfx canister id cap-router)
+  _icHistoryRouter=$(cd ./cap && dfx canister id ic-history-router)
 
   printf "CAP IC History router -> %s\n" "$_icHistoryRouter"
 

--- a/.scripts/required/cap.sh
+++ b/.scripts/required/cap.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CANISTER_CAP_ID=$(cd ./cap && dfx canister id cap-router)
+CANISTER_CAP_ID=$(cd ./cap && dfx canister id ic-history-router)
 
 if [ -z "$CANISTER_CAP_ID" ];
 then

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "NFT Marketplace template",
   "main": "index.js",
   "scripts": {
-    "cap:start": "cd ./cap && dfx deploy cap-router",
+    "cap:start": "cd ./cap && dfx deploy ic-history-router",
     "cap:reset": "cd ./cap && rm -rf .dfx",
     "dab:start": "cd ./dab && dfx deploy nft",
     "dab:reset": "cd ./dab && rm -rf .dfx",


### PR DESCRIPTION
## Why?

The name change cause the service to break.

