### PR TITLE
feat: add controller guard to failed_log()

### DIFF
--- a/marketplace/marketplace.did
+++ b/marketplace/marketplace.did
@@ -56,8 +56,10 @@ type OfferStatus = variant {
   Created;
 };
 type Result = variant { Ok; Err : MPApiError };
-type Result_1 = variant { Ok : nat; Err : MPApiError };
-type Result_2 = variant { Ok : Listing; Err : MPApiError };
+type Result_1 = variant { Ok : vec TxLogEntry; Err : MPApiError };
+type Result_2 = variant { Ok : nat; Err : MPApiError };
+type Result_3 = variant { Ok : Listing; Err : MPApiError };
+type TxLogEntry = record { to : principal; from : principal; memo : text };
 service : (principal, nat, opt principal) -> {
   acceptOffer : (principal, nat, principal) -> (Result);
   addCollection : (
@@ -76,14 +78,16 @@ service : (principal, nat, opt principal) -> {
   denyOffer : (principal, nat, principal) -> (Result);
   dfxInfo : () -> (text) query;
   directBuy : (principal, nat) -> (Result);
+  failed_log : () -> (Result_1) query;
+  fix_balance : (principal, principal, nat) -> (Result);
   getAllBalances : () -> (
       vec record { record { principal; principal }; nat },
     ) query;
   getBuyerOffers : (principal, principal) -> (vec Offer) query;
   getCollections : () -> (vec record { principal; Collection }) query;
-  getFloor : (principal) -> (Result_1) query;
+  getFloor : (principal) -> (Result_2) query;
   getProtocolFee : () -> (nat) query;
-  getTokenListing : (principal, nat) -> (Result_2) query;
+  getTokenListing : (principal, nat) -> (Result_3) query;
   getTokenOffers : (principal, vec nat) -> (
       vec record { nat; vec Offer },
     ) query;

--- a/marketplace/src/main.rs
+++ b/marketplace/src/main.rs
@@ -64,8 +64,12 @@ fn dfx_info() -> &'static str {
 
 #[query]
 #[candid_method(query)]
-fn failed_log() -> Vec<TxLogEntry> {
-    balances(|balances| balances.failed_tx_log_entries.clone())
+async fn failed_log() -> Result<Vec<TxLogEntry>, MPApiError> {
+    if let Err(e) = is_controller(&ic::caller()).await {
+        return Err(MPApiError::Other(format!("{:?}", e)));
+    }
+
+    Ok(balances(|balances| balances.failed_tx_log_entries.clone()))
 }
 
 #[update]


### PR DESCRIPTION
## Why?

guard the failed tx log

Replaces #107 


## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] It does not break existing features (unless required)
- [ ] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [ ] All code formatting pass
- [ ] All lints pass
- [ ] All tests pass

## Security checklist?

- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] Sensitive data has been identified and is being protected properly

## Demo?

Optionally, provide any screenshot, gif or small video.
