### PR TITLE
fix: also fail and remove listing verification if no operator

### DIFF
--- a/marketplace/src/main.rs
+++ b/marketplace/src/main.rs
@@ -422,7 +422,11 @@ pub async fn verify_listing(nft_canister_id: Principal, token_id: Nat) -> MPApiR
                 ));
             }
         }
-        None => (),
+        None => {
+            error = Some(MPApiError::Other(
+                "Cancelling listing, token is not approved for this marketplace".to_string(),
+            ))
+        }
     }
 
     if error.is_some() {


### PR DESCRIPTION
## Why?

if operator is none also fail verification and cancel listing

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] It does not break existing features (unless required)
- [ ] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [ ] All code formatting pass
- [ ] All lints pass
- [ ] All tests pass

## Security checklist?

- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] Sensitive data has been identified and is being protected properly

## Demo?

Optionally, provide any screenshot, gif or small video.
